### PR TITLE
PHP's alte array()-Syntax durch [] ersetzen

### DIFF
--- a/protected/RISParser/BAAntragParser.php
+++ b/protected/RISParser/BAAntragParser.php
@@ -23,7 +23,7 @@ class BAAntragParser extends RISParser
         $daten->id                     = $antrag_id;
         $daten->datum_letzte_aenderung = new CDbExpression('NOW()');
 
-        $dokumente = array();
+        $dokumente = [];
         //$ergebnisse = array();
 
         $dat_details = explode("<!-- bereichsbild, bereichsheadline, allgemeiner text -->", $html_details);
@@ -97,11 +97,11 @@ class BAAntragParser extends RISParser
 
         preg_match_all("/<li><span class=\"iconcontainer\">.*href=\"(.*)\"[^>]*title=\"([^\"]*)\">(.*)<\/a>/siU", $html_dokumente, $matches);
         for ($i = 0; $i < count($matches[1]); $i++) {
-            $dokumente[] = array(
+            $dokumente[] = [
                 "url"        => $matches[1][$i],
                 "name"       => $matches[3][$i],
                 "name_title" => $matches[2][$i],
-            );
+            ];
         }
 
         /*
@@ -185,7 +185,7 @@ class BAAntragParser extends RISParser
         $text = RISTools::load_file("http://www.ris-muenchen.de/RII/BA-RII/ba_antraege.jsp?Start=$seite");
 
         $txt = explode("<!-- tabellenkopf -->", $text);
-        if (!isset($txt[1])) return array();
+        if (!isset($txt[1])) return [];
 
         $txt = explode("<div class=\"ergebnisfuss\">", $txt[1]);
         preg_match_all("/ba_antraege_details\.jsp\?Id=([0-9]+)[\"'& ]/siU", $txt[0], $matches);
@@ -215,7 +215,7 @@ class BAAntragParser extends RISParser
     public function parseUpdate()
     {
         echo "Updates: BA-Anträge\n";
-        $loaded_ids = array();
+        $loaded_ids = [];
 
         $anz = static::$MAX_OFFSET_UPDATE;
         for ($i = $anz; $i >= 0; $i -= 10) {

--- a/protected/RISParser/BAGremienParser.php
+++ b/protected/RISParser/BAGremienParser.php
@@ -60,10 +60,10 @@ class BAGremienParser extends RISParser
         }
 
         /** @var StadtraetInGremium[] $mitglieder_pre */
-        $mitglieder_pre = array();
+        $mitglieder_pre = [];
         if ($alter_eintrag) foreach ($alter_eintrag->mitgliedschaften as $mitgliedschaft) $mitglieder_pre[$mitgliedschaft->stadtraetIn_id] = $mitgliedschaft;
 
-        $mitglieder_post = array();
+        $mitglieder_post = [];
         preg_match_all("/ergebnistab_tr.*<\/tr/siU", $html_details, $matches);
         foreach ($matches[0] as $str) {
             preg_match("/<a[^>]*Id=(?<id>[0-9]+)&[^>]*>(?<name>[^<]*)<\/a>.*<td[^>]*>(?<partei>[^<]*)<\/td.*<td[^>]*>(?<datum>[^<]*)<\/td.*<td[^>]*>(?<funktion>[^<]*)<\/td/siU", $str, $match2);
@@ -77,8 +77,8 @@ class BAGremienParser extends RISParser
 
                     $stadtraetIn = StadtraetIn::model()->findByPk($match2["id"]);
                     if (!$stadtraetIn) {
-                        $name        = trim(str_replace(array("&nbsp;", "Herr", "Frau"), array(" ", " ", " "), $match2["name"]));
-                        $stadtraetIn = StadtraetIn::model()->findByAttributes(array("name" => $name));
+                        $name        = trim(str_replace(["&nbsp;", "Herr", "Frau"], [" ", " ", " "], $match2["name"]));
+                        $stadtraetIn = StadtraetIn::model()->findByAttributes(["name" => $name]);
                         if (!$stadtraetIn) {
                             RISTools::send_email(Yii::app()->params['adminEmail'], "BA-Gremium nicht zuordbar", "Gremium: $gremien_id\nMitglieds-ID: " . $match2["id"], null, "system");
                             return;

--- a/protected/RISParser/BAInitiativeParser.php
+++ b/protected/RISParser/BAInitiativeParser.php
@@ -24,7 +24,7 @@ class BAInitiativeParser extends RISParser
         $daten->datum_letzte_aenderung = new CDbExpression('NOW()');
         $daten->typ                    = Antrag::$TYP_BA_INITIATIVE;
 
-        $dokumente = array();
+        $dokumente = [];
         //$ergebnisse = array();
 
         preg_match("/<h3.*>.* +(.*)<\/h3/siU", $html_details, $matches);
@@ -88,11 +88,11 @@ class BAInitiativeParser extends RISParser
 
         preg_match_all("/<li><span class=\"iconcontainer\">.*title=\"([^\"]+)\"[^>]+href=\"(.*)\".*>(.*)<\/a>/siU", $html_dokumente, $matches);
         for ($i = 0; $i < count($matches[1]); $i++) {
-            $dokumente[] = array(
+            $dokumente[] = [
                 "url"        => $matches[2][$i],
                 "name"       => $matches[3][$i],
                 "name_title" => $matches[1][$i],
-            );
+            ];
         }
 
         /*
@@ -202,7 +202,7 @@ class BAInitiativeParser extends RISParser
     public function parseUpdate()
     {
         echo "Updates: BA-Initiativen\n";
-        $loaded_ids = array();
+        $loaded_ids = [];
         $anz        = static::$MAX_OFFSET_UPDATE;
         for ($i = $anz; $i >= 0; $i -= 10) {
             $ids        = $this->parseSeite($i, false);

--- a/protected/RISParser/BAMitgliederParser.php
+++ b/protected/RISParser/BAMitgliederParser.php
@@ -19,13 +19,13 @@ class BAMitgliederParser extends RISParser
         $x = explode('<!-- tabellenkopf -->', $ba_details);
         $x = explode('<!-- seitenfuss -->', $x[1]);
 
-        $gefundene_fraktionen = array();
+        $gefundene_fraktionen = [];
 
         preg_match_all("/ba_mitglieder_details_mitgliedschaft\.jsp\?Id=(?<mitglied_id>[0-9]+)&amp;Wahlperiode=(?<wahlperiode>[0-9]+)[\"'& ]>(?<name>[^<]*)<.*tdborder\">(?<mitgliedschaft>[^<]*)<\/td>.*tdborder[^>]*>(?<fraktion>[^<]*) *<\/td>.*notdborder[^>]*>(?<funktion>[^<]*) *<\/td.*<\/tr/siU", $x[0], $matches);
         for ($i = 0; $i < count($matches[1]); $i++) {
             $fraktion_name = trim(html_entity_decode($matches["fraktion"][$i]));
             $name          = str_replace("&nbsp;", " ", $matches["name"][$i]);
-            $name          = trim(str_replace(array("Herr", "Frau"), array(" ", " "), $name));
+            $name          = trim(str_replace(["Herr", "Frau"], [" ", " "], $name));
 
             if ($fraktion_name == "")
                 $fraktion_name = "Parteifrei";
@@ -46,7 +46,7 @@ class BAMitgliederParser extends RISParser
             }
 
             /** @var Fraktion|null $fraktion */
-            $fraktion = Fraktion::model()->findByAttributes(array("ba_nr" => $ba_nr, "name" => $fraktion_name));
+            $fraktion = Fraktion::model()->findByAttributes(["ba_nr" => $ba_nr, "name" => $fraktion_name]);
             if (!$fraktion) {
                 echo "Lege an: " . $fraktion_name . "\n";
                 $min = Yii::app()->db->createCommand()->select("MIN(id)")->from("fraktionen")->queryColumn()[0] - 1;
@@ -91,7 +91,7 @@ class BAMitgliederParser extends RISParser
                 }
                 $strfrakt->save();
             }
-            if (!isset($gefundene_fraktionen[$matches["mitglied_id"][$i]])) $gefundene_fraktionen[$matches["mitglied_id"][$i]] = array();
+            if (!isset($gefundene_fraktionen[$matches["mitglied_id"][$i]])) $gefundene_fraktionen[$matches["mitglied_id"][$i]] = [];
             $gefundene_fraktionen[$matches["mitglied_id"][$i]][] = $fraktion->id;
         }
 

--- a/protected/RISParser/BATerminParser.php
+++ b/protected/RISParser/BATerminParser.php
@@ -45,7 +45,7 @@ class BATerminParser extends RISParser
         $daten->datum_letzte_aenderung = new CDbExpression('NOW()');
         $daten->gremium_id             = NULL;
 
-        $dokumente = array();
+        $dokumente = [];
 
         if (preg_match("/ba_gremien_details\.jsp\?Id=([0-9]+)[\"'& ]/siU", $html_details, $matches)) $daten->gremium_id = IntVal($matches[1]);
         if ($daten->gremium_id) {
@@ -61,7 +61,7 @@ class BATerminParser extends RISParser
 
         if (preg_match("/Termin:.*detail_div\">([^&<]+)[&<]/siU", $html_details, $matches)) {
             $termin = $matches[1];
-            $MONATE = array(
+            $MONATE = [
                 "januar"    => "01",
                 "februar"   => "02",
                 "märz"      => "03",
@@ -74,7 +74,7 @@ class BATerminParser extends RISParser
                 "oktober"   => "10",
                 "november"  => "11",
                 "dezember"  => "12",
-            );
+            ];
             $x      = explode(" ", trim($termin));
             $tag    = IntVal($x[1]);
             if ($tag < 10) $tag = "0" . IntVal($tag);
@@ -96,11 +96,11 @@ class BATerminParser extends RISParser
 
         preg_match_all("/<li><span class=\"iconcontainer\">.*title=\"([^\"]+)\"[^>]*href=\"(.*)\".*>(.*)<\/a>/siU", $html_dokumente, $matches);
         for ($i = 0; $i < count($matches[1]); $i++) {
-            $dokumente[] = array(
+            $dokumente[] = [
                 "url"        => $matches[2][$i],
                 "name"       => $matches[3][$i],
                 "name_title" => $matches[1][$i],
-            );
+            ];
         }
 
         $aenderungen = "";
@@ -132,15 +132,15 @@ class BATerminParser extends RISParser
         $matches["betreff"] = RISTools::makeArrValuesUnique($matches["betreff"]);
 
         /** @var Tagesordnungspunkt[] $bisherige_tops */
-        $bisherige_tops          = ($alter_eintrag ? $alter_eintrag->tagesordnungspunkte : array());
+        $bisherige_tops          = ($alter_eintrag ? $alter_eintrag->tagesordnungspunkte : []);
         $aenderungen_tops        = "";
         $abschnitt_nr            = "";
-        $verwendete_top_betreffs = array();
+        $verwendete_top_betreffs = [];
         for ($i = 0; $i < count($matches["top"]); $i++) {
             $betreff = $matches["betreff"][$i];
             if (mb_stripos($betreff, "<strong>") !== false) {
                 $abschnitt_nr = trim($matches["top"][$i], " \t\n\r\0\x0B.");
-                $betreff      = str_replace(array("<strong>", "</strong>"), array("", ""), $betreff);
+                $betreff      = str_replace(["<strong>", "</strong>"], ["", ""], $betreff);
                 if ($abschnitt_nr == "&nbsp;") {
                     if (preg_match("/TOP (?<top>[0-9.]+)+: (?<betreff>.*)/siu", $betreff, $matches2)) {
                         $abschnitt_nr = $matches2["top"];
@@ -205,11 +205,11 @@ class BATerminParser extends RISParser
 
             /** @var Tagesordnungspunkt[] $alte_tops */
             if ($vorlage_id) {
-                $alte_tops = Tagesordnungspunkt::model()->findAllByAttributes(array("sitzungstermin_id" => $termin_id, "antrag_id" => $vorlage_id));
+                $alte_tops = Tagesordnungspunkt::model()->findAllByAttributes(["sitzungstermin_id" => $termin_id, "antrag_id" => $vorlage_id]);
             } elseif ($baantrag_id) {
-                $alte_tops = Tagesordnungspunkt::model()->findAllByAttributes(array("sitzungstermin_id" => $termin_id, "antrag_id" => $baantrag_id));
+                $alte_tops = Tagesordnungspunkt::model()->findAllByAttributes(["sitzungstermin_id" => $termin_id, "antrag_id" => $baantrag_id]);
             } else {
-                $alte_tops = Tagesordnungspunkt::model()->findAllByAttributes(array("sitzungstermin_id" => $termin_id, "top_betreff" => $betreff));
+                $alte_tops = Tagesordnungspunkt::model()->findAllByAttributes(["sitzungstermin_id" => $termin_id, "top_betreff" => $betreff]);
             }
             $alter_top = $this->loescheDoppelteTOPs($alte_tops);
 
@@ -270,7 +270,7 @@ class BATerminParser extends RISParser
 
             preg_match("/<a title=\"(?<title>[^\"]*)\" [^>]*href=\"(?<url>[^ ]+)\"/siU", $entscheidung_original, $matches2);
             if (isset($matches2["url"]) && $matches2["url"] != "" && $matches2["url"] != "/RII/RII/DOK/TOP/") {
-                $aenderungen .= Dokument::create_if_necessary(Dokument::$TYP_BA_BESCHLUSS, $tagesordnungspunkt, array("url" => $matches2["url"], "name" => $matches2["title"], "name_title" => ""));
+                $aenderungen .= Dokument::create_if_necessary(Dokument::$TYP_BA_BESCHLUSS, $tagesordnungspunkt, ["url" => $matches2["url"], "name" => $matches2["title"], "name_title" => ""]);
             }
         }
 

--- a/protected/RISParser/RathausumschauParser.php
+++ b/protected/RISParser/RathausumschauParser.php
@@ -61,7 +61,7 @@ class RathausumschauParser extends RISParser
 
         for ($i = 0; $i < count($matches["url"]); $i++) {
             $datum = explode(".", $matches["datum"][$i]);
-            $ru    = Rathausumschau::model()->findByAttributes(array("jahr" => $datum[2], "nr" => $matches["nr"][$i]));
+            $ru    = Rathausumschau::model()->findByAttributes(["jahr" => $datum[2], "nr" => $matches["nr"][$i]]);
             if (!$ru) {
                 $ru        = new Rathausumschau();
                 $ru->nr    = $matches["nr"][$i];
@@ -75,7 +75,7 @@ class RathausumschauParser extends RISParser
     }
 
 
-    public static $MON_MAPPING = array(
+    public static $MON_MAPPING = [
         "Jan"  => 1,
         "Feb"  => 2,
         "Mrz"  => 3,
@@ -89,7 +89,7 @@ class RathausumschauParser extends RISParser
         "Okt"  => 10,
         "Nov"  => 11,
         "Dez"  => 12,
-    );
+    ];
 
     /* 2009, 2010, 2011 */
     public function parseArchive2($jahr)
@@ -103,7 +103,7 @@ class RathausumschauParser extends RISParser
         for ($i = 0; $i < count($matches["nr"]); $i++) {
             $datum = $jahr . "-" . static::$MON_MAPPING[$matches["mon"][$i]] . "-" . $matches["tag"][$i];
 
-            $ru = Rathausumschau::model()->findByAttributes(array("jahr" => $jahr, "nr" => IntVal($matches["nr"][$i])));
+            $ru = Rathausumschau::model()->findByAttributes(["jahr" => $jahr, "nr" => IntVal($matches["nr"][$i])]);
             if (!$ru) {
                 $ru        = new Rathausumschau();
                 $ru->nr    = IntVal($matches["nr"][$i]);
@@ -116,7 +116,7 @@ class RathausumschauParser extends RISParser
         }
     }
 
-    public static $MONAT_MAPPING = array(
+    public static $MONAT_MAPPING = [
         "Januar"    => 1,
         "Februar"   => 2,
         "März"      => 3,
@@ -129,7 +129,7 @@ class RathausumschauParser extends RISParser
         "Oktober"   => 10,
         "November"  => 11,
         "Dezember"  => 12,
-    );
+    ];
 
     /* 2005, 2006, 2007, 2008 */
     public function parseArchive1($jahr)
@@ -142,7 +142,7 @@ class RathausumschauParser extends RISParser
 
                 if (!isset($datum["monat"])) continue;
 
-                $ru = Rathausumschau::model()->findByAttributes(array("jahr" => $jahr, "nr" => IntVal($file)));
+                $ru = Rathausumschau::model()->findByAttributes(["jahr" => $jahr, "nr" => IntVal($file)]);
                 if (!$ru) {
                     $ru        = new Rathausumschau();
                     $ru->nr    = IntVal($file);

--- a/protected/RISParser/ReferentInnenParser.php
+++ b/protected/RISParser/ReferentInnenParser.php
@@ -49,7 +49,7 @@ class ReferentInnenParser extends RISParser
             }
 
             /** @var Referat $referat */
-            $referat = Referat::model()->findByAttributes(array("name" => $referat_name));
+            $referat = Referat::model()->findByAttributes(["name" => $referat_name]);
             if (!$referat) {
                 RISTools::send_email(Yii::app()->params['adminEmail'], "Referat nicht gefunden", $referat_name, null, "system");
                 return;

--- a/protected/RISParser/StadtraetInnenParser.php
+++ b/protected/RISParser/StadtraetInnenParser.php
@@ -3,7 +3,7 @@
 class StadtraetInnenParser extends RISParser
 {
 
-    private $bearbeitete_stadtraetInnen = array();
+    private $bearbeitete_stadtraetInnen = [];
     private $antraege_alle              = false;
 
     /**
@@ -20,7 +20,7 @@ class StadtraetInnenParser extends RISParser
 
         preg_match_all("/ris_antrag_detail\.jsp\?risid=(?<antrag_id>[0-9]+)[\"'& ]/siU", $antr_text, $matches);
         foreach ($matches["antrag_id"] as $antrag_id) try {
-            Yii::app()->db->createCommand()->insert("antraege_stadtraetInnen", array("antrag_id" => $antrag_id, "stadtraetIn_id" => $stadtraetIn_id, "gefunden_am" => new CDbExpression("NOW()")));
+            Yii::app()->db->createCommand()->insert("antraege_stadtraetInnen", ["antrag_id" => $antrag_id, "stadtraetIn_id" => $stadtraetIn_id, "gefunden_am" => new CDbExpression("NOW()")]);
         } catch (Exception $e) {
         }
     }
@@ -117,7 +117,7 @@ class StadtraetInnenParser extends RISParser
             $str_fraktion->mitgliedschaft = $matches["mitgliedschaft"][$i];
 
             /** @var array|StadtraetInFraktion[] $bisherige_fraktionen */
-            $bisherige_fraktionen = StadtraetInFraktion::model()->findAllByAttributes(array("stadtraetIn_id" => $stadtraetIn_id));
+            $bisherige_fraktionen = StadtraetInFraktion::model()->findAllByAttributes(["stadtraetIn_id" => $stadtraetIn_id]);
             /** @var null|StadtraetInFraktion $bisherige */
 
             $bisherige = null;
@@ -177,7 +177,7 @@ class StadtraetInnenParser extends RISParser
         $txt  = explode("<!-- tabellenkopf -->", $text);
         if (!isset($txt[1])) {
             if (SITE_CALL_MODE != "cron") echo "- leer\n";
-            return array();
+            return [];
         } elseif ($first) {
             RISTools::send_email(Yii::app()->params['adminEmail'], "StadträTinnenUpdate VOLL", "Erste Seite voll: $seite", null, "system");
         }
@@ -199,7 +199,7 @@ class StadtraetInnenParser extends RISParser
     public function parseAlle()
     {
         $anz                              = 350;
-        $this->bearbeitete_stadtraetInnen = array();
+        $this->bearbeitete_stadtraetInnen = [];
         $first                            = true;
         for ($i = $anz; $i >= 0; $i -= 10) {
             if (SITE_CALL_MODE != "cron") echo ($anz - $i) . " / $anz\n";

--- a/protected/RISParser/StadtratTerminParser.php
+++ b/protected/RISParser/StadtratTerminParser.php
@@ -52,7 +52,7 @@ class StadtratTerminParser extends RISParser
 
         if (preg_match("/Termin:.*detail_div\">([^&<]+)[&<]/siU", $html_details, $matches)) {
             $termin = $matches[1];
-            $MONATE = array(
+            $MONATE = [
                 "januar"    => "01",
                 "februar"   => "02",
                 "märz"      => "03",
@@ -65,7 +65,7 @@ class StadtratTerminParser extends RISParser
                 "oktober"   => "10",
                 "november"  => "11",
                 "dezember"  => "12",
-            );
+            ];
             $x      = explode(" ", trim($termin));
             if (isset($x[1])) {
                 $tag = IntVal($x[1]);
@@ -85,15 +85,15 @@ class StadtratTerminParser extends RISParser
             }
         }
 
-        $dokumente = array();
+        $dokumente = [];
 
         preg_match_all("/<li><span class=\"iconcontainer\">.*href=\"(.*)\".*>(.*)<\/a>/siU", $html_dokumente, $matches);
         for ($i = 0; $i < count($matches[1]); $i++) {
-            $dokumente[] = array(
+            $dokumente[] = [
                 "url"        => $matches[1][$i],
                 "name"       => $matches[2][$i],
                 "name_title" => "",
-            );
+            ];
         }
 
         $aenderungen = "";
@@ -134,20 +134,20 @@ class StadtratTerminParser extends RISParser
         $matches["betreff"] = RISTools::makeArrValuesUnique($matches["betreff"]);
 
         /** @var Tagesordnungspunkt[] $bisherige_tops */
-        $bisherige_tops   = ($alter_eintrag ? $alter_eintrag->tagesordnungspunkte : array());
+        $bisherige_tops   = ($alter_eintrag ? $alter_eintrag->tagesordnungspunkte : []);
         $aenderungen_tops = "";
         //$verwendete_top_betreffs = array();
-        $verwendete_top_ids = array();
+        $verwendete_top_ids = [];
         $abschnitt_nr       = 0;
 
         for ($i = 0; $i < count($matches[0]); $i++) {
-            $top     = trim(str_replace(array("&nbsp;", "<strong>", "</strong>"), array(" ", "", ""), $matches["top"][$i]));
+            $top     = trim(str_replace(["&nbsp;", "<strong>", "</strong>"], [" ", "", ""], $matches["top"][$i]));
             $betreff = $matches["betreff"][$i];
             if ($matches["ueberschrift"][$i] == "h") {
                 $abschnitt_nr     = $abschnitt_nr + 1;
                 $top_ueberschrift = true;
                 $top_nr           = $abschnitt_nr;
-                $betreff          = str_replace(array("<strong>", "</strong>"), array("", ""), $betreff);
+                $betreff          = str_replace(["<strong>", "</strong>"], ["", ""], $betreff);
             } else {
                 if ($abschnitt_nr == 0) $abschnitt_nr = 1;
                 $top_ueberschrift = false;
@@ -195,9 +195,9 @@ class StadtratTerminParser extends RISParser
 
             /** @var Tagesordnungspunkt $alter_top */
             if (is_null($vorlage_id)) {
-                $alter_top = Tagesordnungspunkt::model()->findByAttributes(array("sitzungstermin_id" => $termin_id, "top_betreff" => $betreff));
+                $alter_top = Tagesordnungspunkt::model()->findByAttributes(["sitzungstermin_id" => $termin_id, "top_betreff" => $betreff]);
             } else {
-                $alter_top = Tagesordnungspunkt::model()->findByAttributes(array("sitzungstermin_id" => $termin_id, "antrag_id" => $vorlage_id));
+                $alter_top = Tagesordnungspunkt::model()->findByAttributes(["sitzungstermin_id" => $termin_id, "antrag_id" => $vorlage_id]);
             }
 
             $top_aenderungen = "";
@@ -245,9 +245,9 @@ class StadtratTerminParser extends RISParser
 
             preg_match_all("/<a href=(?<url>[^ ]+) title=\"(?<title>[^\"]*)\"/siU", $entscheidung_original, $matches2);
             if (isset($matches2["url"]) && count($matches2["url"]) > 0) {
-                $aenderungen .= Dokument::create_if_necessary(Dokument::$TYP_STADTRAT_BESCHLUSS, $top, array("url" => $matches2["url"][0], "name" => $matches2["title"][0], "name_title" => ""));
+                $aenderungen .= Dokument::create_if_necessary(Dokument::$TYP_STADTRAT_BESCHLUSS, $top, ["url" => $matches2["url"][0], "name" => $matches2["title"][0], "name_title" => ""]);
                 /** @var Dokument $dok */
-                $dok = Dokument::model()->findByAttributes(array("tagesordnungspunkt_id" => $top->id, "url" => $matches2["url"][0], "name" => $matches2["title"][0]));
+                $dok = Dokument::model()->findByAttributes(["tagesordnungspunkt_id" => $top->id, "url" => $matches2["url"][0], "name" => $matches2["title"][0]]);
                 if ($dok && $dok->tagesordnungspunkt_id != $top->id) {
                     echo "Korrgiere ID\n";
                     $dok->tagesordnungspunkt_id = $top->id;
@@ -266,7 +266,7 @@ class StadtratTerminParser extends RISParser
             $referent = static::text_clean_spaces($matches["referent"][$i]);
 
             /** @var Tagesordnungspunkt $top */
-            $krits = array("sitzungstermin_id" => $termin_id, "status" => "geheim", "top_betreff" => $betreff);
+            $krits = ["sitzungstermin_id" => $termin_id, "status" => "geheim", "top_betreff" => $betreff];
             $top   = Tagesordnungspunkt::model()->findByAttributes($krits);
             if (is_null($top)) {
                 $top = new Tagesordnungspunkt();
@@ -299,7 +299,7 @@ class StadtratTerminParser extends RISParser
                 } catch (CDbException $e) {
                     $str = "Vermutlich verwaiste Dokumente (war zuvor: \"" . $top->getName() . "\" in " . $daten->getLink() . ":\n";
                     /** @var Dokument[] $doks */
-                    $doks = Dokument::model()->findAllByAttributes(array("tagesordnungspunkt_id" => $top->id));
+                    $doks = Dokument::model()->findAllByAttributes(["tagesordnungspunkt_id" => $top->id]);
                     foreach ($doks as $dok) {
                         $dok->tagesordnungspunkt_id = null;
                         $dok->save(false);

--- a/protected/RISParser/StadtratsantragParser.php
+++ b/protected/RISParser/StadtratsantragParser.php
@@ -9,7 +9,7 @@ class StadtratsantragParser extends RISParser
     {
         $antrag_id = IntVal($antrag_id);
 
-        if (in_array($antrag_id, array(3258272))) return;
+        if (in_array($antrag_id, [3258272])) return;
 
         if (SITE_CALL_MODE != "cron") echo "- Antrag $antrag_id\n";
 
@@ -24,7 +24,7 @@ class StadtratsantragParser extends RISParser
         $daten->datum_letzte_aenderung = new CDbExpression('NOW()');
         $daten->typ                    = Antrag::$TYP_STADTRAT_ANTRAG;
 
-        $dokumente = array();
+        $dokumente = [];
         // $ergebnisse = array();
 
         $dat_details = explode("<!-- bereichsbild, bereichsheadline, allgemeiner text -->", $html_details);
@@ -96,11 +96,11 @@ class StadtratsantragParser extends RISParser
 
         preg_match_all("/<li><span class=\"iconcontainer\">.*title=\"([^\"]*)\"[^>]*href=\"(.*)\">(.*)<\/a>/siU", $html_dokumente, $matches);
         for ($i = 0; $i < count($matches[1]); $i++) {
-            $dokumente[] = array(
+            $dokumente[] = [
                 "url"        => $matches[2][$i],
                 "name"       => $matches[3][$i],
                 "name_title" => $matches[1][$i],
-            );
+            ];
         }
         /*
         $dat_ergebnisse = explode("<!-- tabellenkopf -->", $html_ergebnisse);
@@ -181,7 +181,7 @@ class StadtratsantragParser extends RISParser
         $txt  = explode("<!-- ergebnisreihen -->", $text);
         if (!isset($txt[1])) {
             if (SITE_CALL_MODE != "cron") echo "- nichts\n";
-            return array();
+            return [];
         }
         $txt = explode("<div class=\"ergebnisfuss\">", $txt[1]);
         preg_match_all("/ris_antrag_detail.jsp\?risid=([0-9]+)[\"'& ]/siU", $txt[0], $matches);
@@ -208,7 +208,7 @@ class StadtratsantragParser extends RISParser
 
     public function parseUpdate()
     {
-        $loaded_ids = array();
+        $loaded_ids = [];
         echo "Updates: Stadtratsanträge\n";
 
         for ($i = static::$MAX_OFFSET_UPDATE; $i >= 0; $i -= 10) {
@@ -227,7 +227,7 @@ class StadtratsantragParser extends RISParser
 
     public function parseQuickUpdate()
     {
-        $loaded_ids = array();
+        $loaded_ids = [];
         echo "Updates (quick): Stadtratsanträge\n";
 
         for ($i = 0; $i <= 3; $i++) {

--- a/protected/RISParser/StadtratsvorlageParser.php
+++ b/protected/RISParser/StadtratsvorlageParser.php
@@ -18,8 +18,8 @@ class StadtratsvorlageParser extends RISParser
         $daten->datum_letzte_aenderung = new CDbExpression('NOW()');
         $daten->typ                    = Antrag::$TYP_STADTRAT_VORLAGE;
 
-        $dokumente  = array();
-        $ergebnisse = array();
+        $dokumente  = [];
+        $ergebnisse = [];
 
         if (strpos($html_details, "ris_vorlagen_kurzinfo.jsp?risid=$vorlage_id")) {
             $html_kurzinfo = RISTools::load_file("http://www.ris-muenchen.de/RII/RII/ris_vorlagen_kurzinfo.jsp?risid=" . $vorlage_id);
@@ -29,7 +29,7 @@ class StadtratsvorlageParser extends RISParser
                 return;
             }
             $txt             = explode("</div>", $txt[1]);
-            $daten->kurzinfo = trim(str_replace(array("<br />", "<p>", "</p>"), array("", "", ""), $txt[0]));
+            $daten->kurzinfo = trim(str_replace(["<br />", "<p>", "</p>"], ["", "", ""], $txt[0]));
         }
 
         $dat_details = explode("<!-- bereichsbild, bereichsheadline, allgemeiner text -->", $html_details);
@@ -107,16 +107,16 @@ class StadtratsvorlageParser extends RISParser
 
         preg_match_all("/<li><span class=\"iconcontainer\">.*title=\"([^\"]+)\"[^>]*href=\"(.*)\">(.*)<\/a>/siU", $html_dokumente, $matches);
         for ($i = 0; $i < count($matches[1]); $i++) {
-            $dokumente[] = array(
+            $dokumente[] = [
                 "url"        => $matches[2][$i],
                 "name"       => $matches[3][$i],
                 "name_title" => $matches[1][$i],
-            );
+            ];
         }
 
 
         preg_match_all("/ris_antrag_detail\.jsp\?risid=([0-9]+)[\"'& ]/siU", $html_details, $matches);
-        $antrag_links = (isset($matches[1]) && is_array($matches[1]) ? $matches[1] : array());
+        $antrag_links = (isset($matches[1]) && is_array($matches[1]) ? $matches[1] : []);
 
         $dat_ergebnisse = explode("<!-- tabellenkopf -->", $html_ergebnisse);
         if (count($dat_ergebnisse) > 1) {
@@ -266,7 +266,7 @@ class StadtratsvorlageParser extends RISParser
         if (SITE_CALL_MODE != "cron") echo "Seite: $seite\n";
         $text = RISTools::load_file("http://www.ris-muenchen.de/RII/RII/ris_vorlagen_trefferliste.jsp?txtSuchbegriff=&txtPosition=$seite");
         $txt  = explode("<!-- ergebnisreihen -->", $text);
-        if (count($txt) == 1) return array();
+        if (count($txt) == 1) return [];
 
         $txt = explode("<div class=\"ergebnisfuss\">", $txt[1]);
         preg_match_all("/ris_vorlagen_detail\.jsp\?risid=([0-9]+)[\"'& ]/siU", $txt[0], $matches);
@@ -297,7 +297,7 @@ class StadtratsvorlageParser extends RISParser
     public function parseUpdate()
     {
         echo "Updates: Stadtratsvorlagen\n";
-        $loaded_ids = array();
+        $loaded_ids = [];
         for ($i = static::$MAX_OFFSET_UPDATE; $i >= 0; $i -= 10) {
             $ids        = $this->parseSeite($i, false);
             $loaded_ids = array_merge($loaded_ids, array_map("IntVal", $ids));

--- a/protected/RISParser/StadtrechtParser.php
+++ b/protected/RISParser/StadtrechtParser.php
@@ -13,7 +13,7 @@ class StadtrechtParser extends RISParser
                 $url_base = "http://www.muenchen.info/dir/recht/" . $matches[1];
                 $titel    = $matches[2];
                 $id       = preg_replace("/\S+\/(\S+)/", "$1", $matches[1]);
-                array_push($all_docs, array($url_base, trim($titel), $id));
+                array_push($all_docs, [$url_base, trim($titel), $id]);
             }
         }
         return $all_docs;
@@ -49,7 +49,7 @@ class StadtrechtParser extends RISParser
             $x    = explode('</BODY>', $x[1]);
             $text = $x[0];
 
-            $html = str_replace(array("<NOBR>", "</NOBR>", "<SPAN", "</SPAN"), array("", "", "<DIV", "</DIV"), $text);
+            $html = str_replace(["<NOBR>", "</NOBR>", "<SPAN", "</SPAN"], ["", "", "<DIV", "</DIV"], $text);
 
 
             preg_match("/text positioning information \*\/\\n(?<css>.*)<\/STYLE/siu", $document, $matches);
@@ -71,8 +71,8 @@ class StadtrechtParser extends RISParser
         $titel = html_entity_decode($titel, ENT_COMPAT, "UTF-8");;
 
         /** @var Rechtsdokument $rechtsdokument */
-        if ($id > 0) $rechtsdokument = Rechtsdokument::model()->findByAttributes(array("id" => $id));
-        else $rechtsdokument = Rechtsdokument::model()->findByAttributes(array("titel" => $titel));
+        if ($id > 0) $rechtsdokument = Rechtsdokument::model()->findByAttributes(["id" => $id]);
+        else $rechtsdokument = Rechtsdokument::model()->findByAttributes(["titel" => $titel]);
         if (!$rechtsdokument) $rechtsdokument = new Rechtsdokument();
 
         $rechtsdokument->url_base = $url_base;

--- a/protected/commands/Benachrichtigungen_DebugCommand.php
+++ b/protected/commands/Benachrichtigungen_DebugCommand.php
@@ -11,7 +11,7 @@ class Benachrichtigungen_DebugCommand extends CConsoleCommand
         if (is_numeric($args[0])) {
             $benutzerIn = BenutzerIn::model()->findByPk($args[0]);
         } else {
-            $benutzerIn = BenutzerIn::model()->findByAttributes(array("email" => $args[0]));
+            $benutzerIn = BenutzerIn::model()->findByAttributes(["email" => $args[0]]);
         }
         if (!$benutzerIn) {
             die("BenutzerIn nicht gefunden.\n");

--- a/protected/commands/Benachrichtigungen_VerschickenCommand.php
+++ b/protected/commands/Benachrichtigungen_VerschickenCommand.php
@@ -62,7 +62,7 @@ class Benachrichtigungen_VerschickenCommand extends CConsoleCommand
             if (is_numeric($args[0])) {
                 $benutzerIn = BenutzerIn::model()->findByPk($args[0]);
             } else {
-                $benutzerIn = BenutzerIn::model()->findByAttributes(array("email" => $args[0]));
+                $benutzerIn = BenutzerIn::model()->findByAttributes(["email" => $args[0]]);
             }
             if (!$benutzerIn) die("BenutzerIn nicht gefunden.\n");
             /** @var BenutzerIn $benutzerIn */

--- a/protected/commands/Delete_DocumentsCommand.php
+++ b/protected/commands/Delete_DocumentsCommand.php
@@ -14,7 +14,7 @@ class Delete_DocumentsCommand extends CConsoleCommand
         if ($args[0] == "alle") {
             $sql = Yii::app()->db->createCommand();
             $sql->select("id")->from("dokumente")->order("id DESC");
-            $data = $sql->queryColumn(array("id"));
+            $data = $sql->queryColumn(["id"]);
 
             for ($i = 0; $i < count($data); $i++) {
                 if (($i % 100) == 0) echo $i . " / " . count($data) . "\n";

--- a/protected/commands/GoogleSitemapCreateCommand.php
+++ b/protected/commands/GoogleSitemapCreateCommand.php
@@ -5,7 +5,7 @@ class GoogleSitemapCreateCommand extends CConsoleCommand
     public function run($args)
     {
 
-        $sitemap_files = array();
+        $sitemap_files = [];
 
         $datumformat = function ($datum) {
             $x = explode(" ", $datum);

--- a/protected/commands/ImportStatistikCommand.php
+++ b/protected/commands/ImportStatistikCommand.php
@@ -8,7 +8,7 @@ class ImportStatistikCommand extends CConsoleCommand
             return FALSE;
 
         $header = NULL;
-        $data   = array();
+        $data   = [];
         if (($handle = fopen($filename, 'r')) !== FALSE) {
             while (($row = fgetcsv($handle, 1000, $delimiter)) !== FALSE) {
                 if (!$header)
@@ -28,7 +28,7 @@ class ImportStatistikCommand extends CConsoleCommand
             die();
         }
         $sql = Yii::app()->db->createCommand();
-        $sql->delete('statistik_datensaetze', array("quelle = " . StatistikDatensatz::QUELLE_BEVOELKERUNG));
+        $sql->delete('statistik_datensaetze', ["quelle = " . StatistikDatensatz::QUELLE_BEVOELKERUNG]);
         $arr = $this->csv_to_array($args[0]);
 
         $floatize = function($in) {

--- a/protected/commands/Rebuild_VorgaengeCommand.php
+++ b/protected/commands/Rebuild_VorgaengeCommand.php
@@ -12,7 +12,7 @@ class Rebuild_VorgaengeCommand extends CConsoleCommand
             $sql = Yii::app()->db->createCommand();
             //$sql->select("id")->from("antraege")->where("id < 1245865 AND (seiten_anzahl = 0 OR seiten_anzahl = 9)")->order("id");
             $sql->select("id")->from("antraege")->where("id < 10561")->order("id DESC");
-            $data = $sql->queryColumn(array("id"));
+            $data = $sql->queryColumn(["id"]);
             foreach ($data as $id) {
                 echo $id . "\n";
                 /** @var Antrag $antrag */

--- a/protected/commands/Recalc_DocumentsCommand.php
+++ b/protected/commands/Recalc_DocumentsCommand.php
@@ -12,9 +12,9 @@ class Recalc_DocumentsCommand extends CConsoleCommand
         if ($args[0] == "alle") {
             $sql = Yii::app()->db->createCommand();
             $sql->select("id")->from("dokumente")->where("id >= 579866")->order("id");
-            $data = $sql->queryColumn(array("id"));
+            $data = $sql->queryColumn(["id"]);
         } else {
-            $data = array(IntVal($args[0]));
+            $data = [IntVal($args[0])];
         }
 
         $anz = count($data);

--- a/protected/commands/Recalc_Ort2BACommand.php
+++ b/protected/commands/Recalc_Ort2BACommand.php
@@ -8,10 +8,10 @@ class Recalc_Ort2BACommand extends CConsoleCommand
 
         if ($args[0] == "alle") {
             /** @var OrtGeo[] $orte */
-            $orte = OrtGeo::model()->findAll(array("order" => "id"));
+            $orte = OrtGeo::model()->findAll(["order" => "id"]);
         } else {
             /** @var OrtGeo[] $orte */
-            $orte = OrtGeo::model()->findAll(array("condition" => "id = " . IntVal($args[0])));
+            $orte = OrtGeo::model()->findAll(["condition" => "id = " . IntVal($args[0])]);
         }
 
 

--- a/protected/commands/Reindex_Antrag_PersonenCommand.php
+++ b/protected/commands/Reindex_Antrag_PersonenCommand.php
@@ -6,7 +6,7 @@ class Reindex_Antrag_PersonenCommand extends CConsoleCommand
     {
 
         /** @var Antrag[] $antraege */
-        $antraege = Antrag::model()->findAll(array("order" => "id", "offset" => 40000, "limit" => 10000));
+        $antraege = Antrag::model()->findAll(["order" => "id", "offset" => 40000, "limit" => 10000]);
         for ($i = 0; $i < count($antraege); $i++) {
             echo $i . " / " . count($antraege) . ": " . $antraege[$i]->id . "\n";
             $antraege[$i]->resetPersonen();

--- a/protected/commands/Reindex_BA_AntragCommand.php
+++ b/protected/commands/Reindex_BA_AntragCommand.php
@@ -9,7 +9,7 @@ class Reindex_BA_AntragCommand extends CConsoleCommand
         $parser = new BAAntragParser();
         if ($args[0] == "ohnereferat") {
             /** @var Antrag[] $antraege */
-            $antraege = Antrag::model()->findAllByAttributes(array("typ" => Antrag::$TYP_BA_ANTRAG, "referat_id" => null));
+            $antraege = Antrag::model()->findAllByAttributes(["typ" => Antrag::$TYP_BA_ANTRAG, "referat_id" => null]);
             foreach ($antraege as $antrag) $parser->parse($antrag->id);
         } elseif ($args[0] == "alle") {
             $parser->parseAlle();

--- a/protected/commands/Reindex_BA_InitiativeCommand.php
+++ b/protected/commands/Reindex_BA_InitiativeCommand.php
@@ -9,7 +9,7 @@ class Reindex_BA_InitiativeCommand extends CConsoleCommand
         $parser = new BAInitiativeParser();
         if ($args[0] == "ohnereferat") {
             /** @var Antrag[] $antraege */
-            $antraege = Antrag::model()->findAllByAttributes(array("typ" => Antrag::$TYP_BA_INITIATIVE, "referat_id" => null));
+            $antraege = Antrag::model()->findAllByAttributes(["typ" => Antrag::$TYP_BA_INITIATIVE, "referat_id" => null]);
             foreach ($antraege as $antrag) $parser->parse($antrag->id);
         } elseif ($args[0] == "alle") {
             $parser->parseAlle();

--- a/protected/commands/Reindex_DocumentCommand.php
+++ b/protected/commands/Reindex_DocumentCommand.php
@@ -8,7 +8,7 @@ class Reindex_DocumentCommand extends CConsoleCommand
 
         $sql = Yii::app()->db->createCommand();
         $sql->select("id")->from("dokumente")->where("id = " . IntVal($args[0]));
-        $data = $sql->queryColumn(array("id"));
+        $data = $sql->queryColumn(["id"]);
 
         $anz = count($data);
         foreach ($data as $nr => $dok_id) {

--- a/protected/commands/Reindex_DocumentsCommand.php
+++ b/protected/commands/Reindex_DocumentsCommand.php
@@ -12,7 +12,7 @@ class Reindex_DocumentsCommand extends CConsoleCommand
         //$sql->select("id")->from("dokumente")->where("datum < NOW() - INTERVAL 2 MONTH AND datum > NOW() - INTERVAL 3 MONTH")->order("id");
         //$sql->select("id")->from("dokumente")->where("text_pdf = '' AND url LIKE '%pdf'")->order("id");
         $sql->select("id")->from("dokumente")->where("id <= " . IntVal($max_id))->order("id DESC");
-        $data = $sql->queryColumn(array("id"));
+        $data = $sql->queryColumn(["id"]);
 
         $anz = count($data);
         foreach ($data as $nr => $dok_id) {

--- a/protected/commands/Reindex_Solr_DocumentsCommand.php
+++ b/protected/commands/Reindex_Solr_DocumentsCommand.php
@@ -8,15 +8,15 @@ class Reindex_Solr_DocumentsCommand extends CConsoleCommand
         if (!isset($args[0])) die("./yiic reindexsolr_documents [id]|stadtrat_beschluss|ba_beschluss|alle [offset]\n");
 
         if ($args[0] > 0) {
-            $data = array($args[0]);
+            $data = [$args[0]];
         } elseif ($args[0] == "alle") {
             $sql = Yii::app()->db->createCommand();
             $sql->select("id")->from("dokumente")->where("id >= 0")->order("id");
-            $data = $sql->queryColumn(array("id"));
+            $data = $sql->queryColumn(["id"]);
         } elseif (isset(Dokument::$TYPEN_ALLE[$args[0]])) {
             $sql = Yii::app()->db->createCommand();
             $sql->select("id")->from("dokumente")->where("typ = '" . addslashes($args[0]) . "'")->order("id");
-            $data = $sql->queryColumn(array("id"));
+            $data = $sql->queryColumn(["id"]);
         } else {
             die("./yiic reindexsolr_documents [id]|stadtrat_beschluss|ba_beschluss|rathausumschau|alle\n");
         }

--- a/protected/commands/Reindex_Stadtrat_AntragCommand.php
+++ b/protected/commands/Reindex_Stadtrat_AntragCommand.php
@@ -9,7 +9,7 @@ class Reindex_Stadtrat_AntragCommand extends CConsoleCommand
         $parser = new StadtratsantragParser();
         if ($args[0] == "ohnereferat") {
             /** @var Antrag[] $antraege */
-            $antraege = Antrag::model()->findAllByAttributes(array("typ" => Antrag::$TYP_STADTRAT_ANTRAG, "referat_id" => null));
+            $antraege = Antrag::model()->findAllByAttributes(["typ" => Antrag::$TYP_STADTRAT_ANTRAG, "referat_id" => null]);
             foreach ($antraege as $antrag) $parser->parse($antrag->id);
         } elseif ($args[0] == "alle") {
             $parser->parseAlle();

--- a/protected/commands/Reindex_Stadtrat_VorlageCommand.php
+++ b/protected/commands/Reindex_Stadtrat_VorlageCommand.php
@@ -9,7 +9,7 @@ class Reindex_Stadtrat_VorlageCommand extends CConsoleCommand
         $parser = new StadtratsvorlageParser();
         if ($args[0] == "ohnereferat") {
             /** @var Antrag[] $antraege */
-            $antraege = Antrag::model()->findAllByAttributes(array("typ" => Antrag::$TYP_STADTRAT_VORLAGE, "referat_id" => null));
+            $antraege = Antrag::model()->findAllByAttributes(["typ" => Antrag::$TYP_STADTRAT_VORLAGE, "referat_id" => null]);
             foreach ($antraege as $antrag) $parser->parse($antrag->id);
         } elseif ($args[0] == "alle") {
             $parser->parseAlle();

--- a/protected/commands/Setze_PasswortCommand.php
+++ b/protected/commands/Setze_PasswortCommand.php
@@ -7,7 +7,7 @@ class Setze_PasswortCommand extends CConsoleCommand
         if (count($args) != 2) die("./yii setze_passwort E-Mail-Adresse Neues-Passwort\n");
 
         /** @var BenutzerIn $benutzerIn */
-        $benutzerIn = BenutzerIn::model()->findByAttributes(array("email" => $args[0]));
+        $benutzerIn = BenutzerIn::model()->findByAttributes(["email" => $args[0]]);
         if (!$benutzerIn) {
             echo "KeinE BenutzerIn mit dieser E-Mail-Adresse gefunden.\n";
             return;

--- a/protected/commands/StrassenEinlesenCommand.php
+++ b/protected/commands/StrassenEinlesenCommand.php
@@ -16,7 +16,7 @@ class StrassenEinlesenCommand extends CConsoleCommand
                 $strassenname = preg_replace("/(s)tra(ß|ss)e$/siu", "\\1tr.", trim(strip_tags($y[0])));
                 $plz          = trim(strip_tags($y[1]));
 
-                $str = Strasse::model()->findByAttributes(array("name" => $strassenname));
+                $str = Strasse::model()->findByAttributes(["name" => $strassenname]);
                 if (!$str) {
                     echo "Neu: " . $plz . " - " . $strassenname . "\n";
                     $str          = new Strasse();

--- a/protected/commands/TestCalDAVCommand.php
+++ b/protected/commands/TestCalDAVCommand.php
@@ -9,9 +9,9 @@ class TestCalDAVCommand extends CConsoleCommand
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_USERPWD, "user:pw");
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "REPORT");
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
             "Content-Type: text/xml",
-        ));
+        ]);
         curl_setopt($ch, CURLOPT_POSTFIELDS, '<?xml version="1.0" encoding="UTF-8"?><calendar-query xmlns="urn:ietf:params:xml:ns:caldav"><prop xmlns="DAV:"><getetag /></prop><filter><comp-filter name="VCALENDAR"><comp-filter name="VEVENT"><time-range start="20150111T000000Z" end="20150712T000000Z" /></comp-filter></comp-filter></filter></calendar-query>');
 
         $output = curl_exec($ch);

--- a/protected/commands/TestTitelKorrekturCommand.php
+++ b/protected/commands/TestTitelKorrekturCommand.php
@@ -4,27 +4,27 @@ class TestTitelKorrekturCommand extends CConsoleCommand
 {
     public function run($args)
     {
-        $TESTS_TITEL = array(
-            array(
+        $TESTS_TITEL = [
+            [
                 'input'      => 'Welche Schäden hat der Aufbau des ?Cotton Club? verursacht?',
                 'korrigiert' => 'Welche Schäden hat der Aufbau des „Cotton Club“ verursacht?'
-            ),
-            array(
+            ],
+            [
                 'input'      => 'Fortschreibung des Standortkonzepts "Kulturstrand" 2015 ff.',
                 'korrigiert' => 'Fortschreibung des Standortkonzepts „Kulturstrand“ 2015 ff.'
-            ),
-        );
+            ],
+        ];
 
-        $TESTS_DOKUMENT = array(
-            array(
+        $TESTS_DOKUMENT = [
+            [
                 'input'      => 'Neuer Titel',
                 'korrigiert' => 'Neuer Titel'
-            ),
-            array(
+            ],
+            [
                 'input'      => 'Hinweis fuer Internet',
                 'korrigiert' => 'Hinweis für Internet'
-            ),
-        );
+            ],
+        ];
 
         $allesok = true;
         foreach ($TESTS_TITEL as $test) {

--- a/protected/components/HistorienEintragAntrag.php
+++ b/protected/components/HistorienEintragAntrag.php
@@ -34,7 +34,7 @@ class HistorienEintragAntrag implements HistorienEintrag
      */
     public function getFormattedDiff()
     {
-        $felder = array();
+        $felder = [];
         if ($this->antrag_alt->betreff != $this->antrag_neu->betreff) $felder[] = new HistorienEintragFeld(
             "Betreff", CHtml::encode($this->antrag_alt->betreff), CHtml::encode($this->antrag_neu->betreff)
         );

--- a/protected/components/RISBaseController.php
+++ b/protected/components/RISBaseController.php
@@ -22,13 +22,13 @@ class RISBaseController extends CController
     /**
      * @var array context menu items. This property will be assigned to {@link CMenu::items}.
      */
-    public $menu = array();
+    public $menu = [];
     /**
      * @var array the breadcrumbs of the current page. The value of this property will
      * be assigned to {@link CBreadcrumbs::links}. Please refer to {@link CBreadcrumbs::links}
      * for more details on how to specify this property.
      */
-    public $breadcrumbs = array();
+    public $breadcrumbs = [];
 
     public $top_menu = "";
 
@@ -60,7 +60,7 @@ class RISBaseController extends CController
 
             $path = getcwd() . $this->_assetsBase . "/";
             if (!file_exists($path . "bas.js")) {
-                $BAfeatures = array();
+                $BAfeatures = [];
                 /** @var array|Bezirksausschuss[] $BAs */
                 $BAs = Bezirksausschuss::model()->findAll();
                 foreach ($BAs as $ba) $BAfeatures[] = $ba->toGeoJSONArray();
@@ -100,7 +100,7 @@ class RISBaseController extends CController
 
         if (AntiXSS::isTokenSet("login_anlegen") && $user->isGuest && !isset($_REQUEST["register"])) {
             /** @var BenutzerIn $benutzerIn */
-            $benutzerIn = BenutzerIn::model()->findByAttributes(array("email" => $_REQUEST["email"]));
+            $benutzerIn = BenutzerIn::model()->findByAttributes(["email" => $_REQUEST["email"]]);
             if ($benutzerIn) {
                 if ($benutzerIn->validate_password($_REQUEST["password"])) {
                     $identity = new RISUserIdentity($benutzerIn);
@@ -115,9 +115,9 @@ class RISBaseController extends CController
 
         if (AntiXSS::isTokenSet("login_anlegen") && $user->isGuest && isset($_REQUEST["register"])) {
             /** @var BenutzerIn[] $gefundene_benutzerInnen */
-            $gefundene_benutzerInnen = BenutzerIn::model()->findAll(array(
+            $gefundene_benutzerInnen = BenutzerIn::model()->findAll([
                 "condition" => "email='" . addslashes($_REQUEST["email"]) . "'"
-            ));
+            ]);
             if (count($gefundene_benutzerInnen) > 0) {
                 $this->msg_err = "Es existiert bereits ein Zugang für diese E-Mail-Adresse";
             } elseif (trim($_REQUEST["password"]) == "") {
@@ -152,9 +152,9 @@ class RISBaseController extends CController
         $this->performLoginActions($code);
 
         if (Yii::app()->getUser()->isGuest) {
-            $this->render("../index/login", array(
+            $this->render("../index/login", [
                 "current_url" => $target_url,
-            ));
+            ]);
             Yii::app()->end();
         } else {
             $benutzerIn = $this->aktuelleBenutzerIn();
@@ -173,7 +173,7 @@ class RISBaseController extends CController
         $user = Yii::app()->getUser();
         if ($user->isGuest) return null;
         /** @var BenutzerIn $ich */
-        $ich = BenutzerIn::model()->findByAttributes(array("email" => Yii::app()->user->id));
+        $ich = BenutzerIn::model()->findByAttributes(["email" => Yii::app()->user->id]);
         return $ich;
     }
 
@@ -193,10 +193,10 @@ class RISBaseController extends CController
      */
     public function errorMessageAndDie($error_code, $error_message)
     {
-        $this->render("../index/error", array(
+        $this->render("../index/error", [
             "code"    => $error_code,
             "message" => $error_message,
-        ));
+        ]);
         Yii::app()->end($error_code);
         die();
     }

--- a/protected/components/RISGeo.php
+++ b/protected/components/RISGeo.php
@@ -8,13 +8,13 @@ class RISGeo
     /** @var null|array|Strasse[] */
     public static $STREETS = null;
 
-    public static $RIS_STREET_IGNORE_STREETS = array(
+    public static $RIS_STREET_IGNORE_STREETS = [
         "tal",
-    );
+    ];
 
     public static function get_RIS_STREET_CLEAN_REPLACES_1()
     {
-        return array(
+        return [
             "."              => "",
             "-"              => "",
             "ö"              => "oe",
@@ -29,17 +29,17 @@ class RISGeo
             "\n "            => " ",
             "\n"             => " ",
             "  "             => " ",
-        );
+        ];
     }
 
     public static function get_RIS_STREET_CLEAN_REPLACES_2()
     {
-        return array(
+        return [
             "e ost"        => "e#ost",
             "ende weg"     => "ende#weg",
             "ortskern str" => "ortskern#str",
             "frauenhofer"  => "fraunhofer",
-        );
+        ];
     }
 
     public static function addressToGeo($land, $plz, $ort, $strasse)
@@ -50,8 +50,8 @@ class RISGeo
     public static function init_streets()
     {
         if (static::$STREETS_INITIALIZED) return;
-        $streets_by_length = array();
-        $streets_by_norm   = array();
+        $streets_by_length = [];
+        $streets_by_norm   = [];
         $maxlength         = 0;
 
         /** @var array|Strasse[] $strassen */
@@ -61,11 +61,11 @@ class RISGeo
             $strasse->name_normalized = $norm;
             $streets_by_norm[$norm]   = $strasse;
             $l                        = mb_strlen($norm);
-            if (!isset($streets_by_length[$l])) $streets_by_length[$l] = array();
+            if (!isset($streets_by_length[$l])) $streets_by_length[$l] = [];
             $streets_by_length[$l][] = $norm;
             if ($l > $maxlength) $maxlength = $l;
         }
-        static::$STREETS = array();
+        static::$STREETS = [];
         for ($i = $maxlength; $i > 0; $i--) if (isset($streets_by_length[$i])) foreach ($streets_by_length[$i] as $n) {
             if (!in_array($n, static::$RIS_STREET_IGNORE_STREETS)) static::$STREETS[] = $streets_by_norm[$n];
         }
@@ -80,7 +80,7 @@ class RISGeo
 
         $name = strtolower($name);
 
-        $froms                       = $tos = array();
+        $froms                       = $tos = [];
         $RIS_STREET_CLEAN_REPLACES_1 = static::get_RIS_STREET_CLEAN_REPLACES_1();
         foreach ($RIS_STREET_CLEAN_REPLACES_1 as $key => $val) {
             $froms[] = $key;
@@ -93,7 +93,7 @@ class RISGeo
         $name = preg_replace("/[\n\r]+([0-9])/", "#\\2", $name);
         $name = preg_replace("/[0-9]+[,\\.][0-9]+/", "", $name);
 
-        $froms                       = $tos = array();
+        $froms                       = $tos = [];
         $RIS_STREET_CLEAN_REPLACES_2 = static::get_RIS_STREET_CLEAN_REPLACES_2();
         foreach ($RIS_STREET_CLEAN_REPLACES_2 as $key => $val) {
             $froms[] = $key;
@@ -111,7 +111,7 @@ class RISGeo
     {
         static::init_streets();
         $antragtext    = static::ris_street_cleanstring($str);
-        $streets_found = array();
+        $streets_found = [];
         foreach (static::$STREETS as $street) {
             $offset      = -1;
             $last_offset = -1;
@@ -137,12 +137,12 @@ class RISGeo
             }
         }
 
-        $streets_found_consolidated = array();
+        $streets_found_consolidated = [];
         foreach ($streets_found as $street) {
-            $street_short       = str_replace(array(" str", "-str"), array("str", "str"), mb_strtolower($street));
+            $street_short       = str_replace([" str", "-str"], ["str", "str"], mb_strtolower($street));
             $laengeres_gefunden = false;
             foreach ($streets_found as $street_cmp) {
-                $street_cmp_short = str_replace(array(" str", "-str"), array("str", "str"), mb_strtolower($street_cmp));
+                $street_cmp_short = str_replace([" str", "-str"], ["str", "str"], mb_strtolower($street_cmp));
                 if (mb_strpos($street_cmp_short, $street_short) !== false && mb_strlen($street_short) < mb_strlen($street_cmp_short)) {
                     $laengeres_gefunden = true;
                 }

--- a/protected/components/RISPDF2Text.php
+++ b/protected/components/RISPDF2Text.php
@@ -3,7 +3,7 @@
 class RISPDF2Text
 {
 
-    public static $RIS_OCR_CLEAN_I_REPLACES = array(
+    public static $RIS_OCR_CLEAN_I_REPLACES = [
         "ı"           => "i",
         "vv"          => "w",
         "Munchen"     => "München",
@@ -27,9 +27,9 @@ class RISPDF2Text
         "vWWv"        => "www",
         "Vlﬁ"         => "Wi",
         "Scn"         => "sch",
-    );
+    ];
 
-    public static $RIS_OCR_CLEAN_REPLACES = array(
+    public static $RIS_OCR_CLEAN_REPLACES = [
         "nıv"     => "rw",
         " lsar"   => " Isar",
         "-lsar"   => "-Isar",
@@ -46,14 +46,14 @@ class RISPDF2Text
         "MVGISWM" => "MVG/SWM",
         "tiich"   => "tlich",
         "Schuie"  => "Schule",
-    );
+    ];
 
-    public static $RIS_OCR_CLEAN_PREG_REPLACES = array(
+    public static $RIS_OCR_CLEAN_PREG_REPLACES = [
         "/^l([bcdfghkmnpqrstvwxz])/um" => "I\\1",
         "/ l([bcdfghkmnpqrstvwxz])/um" => " I\\1",
         "/ i([aeou])/um"               => " l\\1",
         "/(niv)(?!eau)/u"              => "rw",
-    );
+    ];
 
     /**
      * @param string $filename
@@ -61,7 +61,7 @@ class RISPDF2Text
      */
     public static function document_pdf_metadata($filename)
     {
-        $result = array();
+        $result = [];
         exec(PATH_PDFINFO . " '" . addslashes($filename) . "'", $result);
         $seiten = 0;
         $datum  = "";
@@ -76,14 +76,14 @@ class RISPDF2Text
             }
         }
 
-        if ($seiten > 0) return array("seiten" => $seiten, "datum" => $datum);
+        if ($seiten > 0) return ["seiten" => $seiten, "datum" => $datum];
 
-        $result = array();
+        $result = [];
         exec(PATH_IDENTIFY . " $filename", $result);
         $anzahl = 0;
         foreach ($result as $res) if (strpos($res, "DirectClass")) $anzahl++;
 
-        return array("seiten" => $anzahl, "datum" => $datum);
+        return ["seiten" => $anzahl, "datum" => $datum];
     }
 
     /**

--- a/protected/components/RISSolrDocument.php
+++ b/protected/components/RISSolrDocument.php
@@ -35,7 +35,7 @@ class RISSolrDocument implements Solarium\QueryType\Update\Query\Document\Docume
      * @param array $boosts
      * @param array $modifiers
      */
-    public function __construct(array $fields = array(), array $boosts = array(), array $modifiers = array())
+    public function __construct(array $fields = [], array $boosts = [], array $modifiers = [])
     {
     }
 }

--- a/protected/components/RISSucheKrits.php
+++ b/protected/components/RISSucheKrits.php
@@ -4,7 +4,7 @@ class RISSucheKrits
 {
 
     /** @var array */
-    public $krits = array();
+    public $krits = [];
 
     /**
      * @param string|array $krits
@@ -128,7 +128,7 @@ class RISSucheKrits
      */
     public function getUrlArray()
     {
-        $krits = $vals = array();
+        $krits = $vals = [];
         foreach ($this->krits as $krit) {
             $krits[] = $krit["typ"];
             if ($krit["typ"] == "geo") $vals[] = $krit["lng"] . "-" . $krit["lat"] . "-" . $krit["radius"];
@@ -136,7 +136,7 @@ class RISSucheKrits
             elseif ($krit["typ"] == "referat") $vals[] = $krit["referat_id"];
             else $vals[] = $krit["suchbegriff"];
         }
-        return array("krit_typ" => $krits, "krit_val" => $vals);
+        return ["krit_typ" => $krits, "krit_val" => $vals];
     }
 
     /**
@@ -272,8 +272,8 @@ class RISSucheKrits
      */
     public function getBenachrichtigungKrits()
     {
-        $krits = array();
-        foreach ($this->krits as $krit) if (!in_array($krit["typ"], array("antrag_wahlperiode"))) $krits[] = $krit;
+        $krits = [];
+        foreach ($this->krits as $krit) if (!in_array($krit["typ"], ["antrag_wahlperiode"])) $krits[] = $krit;
         return new RISSucheKrits($krits);
     }
 
@@ -297,21 +297,21 @@ class RISSucheKrits
                 return "Volltextsuche nach \"" . $such . "\"";
             case "ba":
                 /** @var Bezirksausschuss $ba */
-                $ba = Bezirksausschuss::model()->findByAttributes(array("ba_nr" => $this->krits[0]["ba_nr"]));
+                $ba = Bezirksausschuss::model()->findByAttributes(["ba_nr" => $this->krits[0]["ba_nr"]]);
                 return "Bezirksausschuss " . $ba->ba_nr . ": " . $ba->name;
             case "geo":
                 $ort = OrtGeo::findClosest($this->krits[0]["lng"], $this->krits[0]["lat"]);
                 $title = "Dokumente mit Ortsbezug (ungefähr: " . IntVal($this->krits[0]["radius"]) . "m um \"" . $ort->ort . "\")";
                 if ($dokument) {
                     /** @var OrtGeo[] $gefundene_orte */
-                    $gefundene_orte = array();
+                    $gefundene_orte = [];
                     foreach ($dokument->orte as $dok_ort_ort) {
                         $dok_ort = $dok_ort_ort->ort;
                         $distance = RISGeo::getDistance($dok_ort->lat, $dok_ort->lon, $this->krits[0]["lat"], $this->krits[0]["lng"]);
                         if (($distance * 1000) <= $this->krits[0]["radius"]) $gefundene_orte[] = $dok_ort;
                     }
                     if (count($gefundene_orte) > 0) {
-                        $namen = array();
+                        $namen = [];
                         foreach ($gefundene_orte as $gef_ort) $namen[] = $gef_ort->ort;
                         $title .= ": " . implode(", ", $namen);
                     }
@@ -328,7 +328,7 @@ class RISSucheKrits
                 return "Antrag Nr. " . str_replace("*", " ", $this->krits[0]["suchbegriff"]);
         }
         if (count($this->krits) > 1) {
-            $krits = array();
+            $krits = [];
             foreach ($this->krits as $cr) switch ($cr["typ"]) {
                 case "betreff":
                     $krits[] = "mit \"" . $cr["suchbegriff"] . "\" im Betreff";
@@ -341,7 +341,7 @@ class RISSucheKrits
                     break;
                 case "ba":
                     /** @var Bezirksausschuss $ba */
-                    $ba      = Bezirksausschuss::model()->findByAttributes(array("ba_nr" => $cr["ba_nr"]));
+                    $ba      = Bezirksausschuss::model()->findByAttributes(["ba_nr" => $cr["ba_nr"]]);
                     $krits[] = "aus dem Bezirksausschuss " . $ba->ba_nr . ": " . $ba->name;
                     break;
                 case "geo":
@@ -380,10 +380,10 @@ class RISSucheKrits
      */
     public function addVolltextsucheKrit($str)
     {
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"         => "volltext",
             "suchbegriff" => $str
-        );
+        ];
         return $this;
     }
 
@@ -395,12 +395,12 @@ class RISSucheKrits
      */
     public function addGeoKrit($lng, $lat, $radius)
     {
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"    => "geo",
             "lng"    => FloatVal($lng),
             "lat"    => FloatVal($lat),
             "radius" => FloatVal($radius)
-        );
+        ];
         return $this;
     }
 
@@ -410,19 +410,19 @@ class RISSucheKrits
      */
     public function addBAKrit($ba_nr)
     {
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"   => "ba",
             "ba_nr" => IntVal($ba_nr)
-        );
+        ];
         return $this;
     }
 
     public function addReferatKrit($referat_id)
     {
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"        => "referat",
             "referat_id" => IntVal($referat_id)
-        );
+        ];
         return $this;
     }
 
@@ -432,10 +432,10 @@ class RISSucheKrits
      */
     public function addAntragTypKrit($str)
     {
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"         => "antrag_typ",
             "suchbegriff" => $str
-        );
+        ];
         return $this;
     }
 
@@ -446,10 +446,10 @@ class RISSucheKrits
      */
     public function addWahlperiodeKrit($str)
     {
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"         => "antrag_wahlperiode",
             "suchbegriff" => $str
-        );
+        ];
         return $this;
     }
 
@@ -459,10 +459,10 @@ class RISSucheKrits
      */
     public function addBetreffKrit($str)
     {
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"         => "betreff",
             "suchbegriff" => $str
-        );
+        ];
         return $this;
     }
 
@@ -474,10 +474,10 @@ class RISSucheKrits
     {
         $str           = preg_replace("/[^a-zA-Z0-9 \/-]/siu", "", $str);
         $str           = preg_replace("/ +/siu", "*", $str);
-        $this->krits[] = array(
+        $this->krits[] = [
             "typ"         => "antrag_nr",
             "suchbegriff" => $str,
-        );
+        ];
         return $this;
     }
 

--- a/protected/components/RISTools.php
+++ b/protected/components/RISTools.php
@@ -26,7 +26,7 @@ class RISTools
      */
     public static function bracketEscape($string)
     {
-        return str_replace(array("[", "]"), array(urlencode("["), urlencode("]")), $string);
+        return str_replace(["[", "]"], [urlencode("["), urlencode("]")], $string);
     }
 
     /**
@@ -127,7 +127,7 @@ class RISTools
         $date = explode("-", $x[0]);
 
         if (count($x) == 2) $time = explode(":", $x[1]);
-        else $time = array(0, 0, 0);
+        else $time = [0, 0, 0];
 
         return mktime($time[0], $time[1], $time[2], $date[1], $date[2], $date[0]);
     }
@@ -154,8 +154,8 @@ class RISTools
      */
     public static function rssent($text)
     {
-        $search  = array("<br>", "&", "\"", "<", ">", "'", "–");
-        $replace = array("\n", "&amp;", "&quot;", "&lt;", "&gt;", "&apos;", "-");
+        $search  = ["<br>", "&", "\"", "<", ">", "'", "–"];
+        $replace = ["\n", "&amp;", "&quot;", "&lt;", "&gt;", "&apos;", "-"];
         return str_replace($search, $replace, $text);
     }
 
@@ -232,7 +232,7 @@ class RISTools
             return $matches["anfang"] . " (" . trim($matches["name"]) . ")";
         }, $titel);
 
-        $titel = str_replace(array("Ae", "Oe", "Ue", "ae", "oe", "ue"), array("Ä", "Ö", "Ü", "ä", "ö", "ü"), $titel); // @TODO: False positives filtern? Geht das überhaupt?
+        $titel = str_replace(["Ae", "Oe", "Ue", "ae", "oe", "ue"], ["Ä", "Ö", "Ü", "ä", "ö", "ü"], $titel); // @TODO: False positives filtern? Geht das überhaupt?
         $titel = preg_replace("/(n)eü/siu", "$1eue", $titel);
         $titel = preg_replace("/aü/siu", "aue", $titel);
 
@@ -250,7 +250,7 @@ class RISTools
     public static function normalize_antragvon($str)
     {
         $a   = explode(",", $str);
-        $ret = array();
+        $ret = [];
         foreach ($a as $y) {
             $z = explode(";", $y);
             if (count($z) == 2) $y = $z[1] . " " . $z[0];
@@ -275,7 +275,7 @@ class RISTools
             for ($i = 0; $i < 10; $i++) $y = str_replace("  ", " ", $y);
             $y = str_replace("Zeilhofer-Rath", "Zeilnhofer-Rath", $y);
 
-            if (trim($y) != "") $ret[] = array("name" => $name_orig, "name_normalized" => $y);
+            if (trim($y) != "") $ret[] = ["name" => $name_orig, "name_normalized" => $y];
         }
         return $ret;
     }
@@ -289,7 +289,7 @@ class RISTools
     public function ris_get_person_by_name($name_normalized, $name)
     {
         /** @var Person $p */
-        $p = Person::model()->findByAttributes(array("name_normalized" => $name_normalized));
+        $p = Person::model()->findByAttributes(["name_normalized" => $name_normalized]);
         if ($p) return $p;
         echo "$name / $name_normalized \n";
 
@@ -384,37 +384,37 @@ class RISTools
     public static function send_email_mandrill($email, $betreff, $text_plain, $text_html = null, $mail_tag = null)
     {
         $mandrill = new Mandrill(MANDRILL_API_KEY);
-        $tags     = array();
+        $tags     = [];
         if ($mail_tag !== null) $tags[] = $mail_tag;
 
-        $headers = array();
+        $headers = [];
         if ($mail_tag == 'newsletter') {
             $headers['Precedence']     = 'bulk';
             $headers['Auto-Submitted'] = 'auto-generated';
         }
 
-        $message = array(
+        $message = [
             'html'         => $text_html,
             'text'         => $text_plain,
             'subject'      => $betreff,
             'from_email'   => Yii::app()->params["adminEmail"],
             'from_name'    => Yii::app()->params["adminEmailName"],
-            'to'           => array(
-                array(
+            'to'           => [
+                [
                     "name"  => null,
                     "email" => $email,
                     "type"  => "to",
-                )
-            ),
+                ]
+            ],
             'important'    => false,
             'tags'         => $tags,
             'track_clicks' => false,
             'track_opens'  => false,
             'inline_css'   => true,
             'headers'      => $headers,
-        );
+        ];
 
-        if (in_array($mail_tag, array("email", "password"))) $message["view_content_link"] = false;
+        if (in_array($mail_tag, ["email", "password"])) $message["view_content_link"] = false;
 
         $mandrill->messages->send($message, false);
     }
@@ -445,7 +445,7 @@ class RISTools
             $html_part->type    = "text/html";
             $html_part->charset = "UTF-8";
             $mimem              = new Zend\Mime\Message();
-            $mimem->setParts(array($text_part, $html_part));
+            $mimem->setParts([$text_part, $html_part]);
 
             $mail->setBody($mimem);
             $mail->getHeaders()->get('content-type')->setType('multipart/alternative');
@@ -466,12 +466,12 @@ class RISTools
      */
     public static function makeArrValuesUnique($arr)
     {
-        $val_count = array();
+        $val_count = [];
         foreach ($arr as $elem) {
             if (isset($val_count[$elem])) $val_count[$elem]++;
             else $val_count[$elem] = 1;
         }
-        $vals_used = array();
+        $vals_used = [];
         foreach ($arr as $i => $elem) {
             if ($val_count[$elem] == 1) continue;
             if (isset($vals_used[$elem])) $vals_used[$elem]++;
@@ -488,14 +488,14 @@ class RISTools
     public static function insertTooltips($text_html)
     {
         /** @var Text[] $eintraege */
-        $eintraege    = Text::model()->findAllByAttributes(array(
+        $eintraege    = Text::model()->findAllByAttributes([
             "typ" => Text::$TYP_GLOSSAR,
-        ));
-        $regexp_parts = array();
+        ]);
+        $regexp_parts = [];
         /** @var Text[] $tooltip_replaces */
-        $tooltip_replaces = array();
+        $tooltip_replaces = [];
         foreach ($eintraege as $ein) {
-            $aliases = array(strtolower($ein->titel));
+            $aliases = [strtolower($ein->titel)];
             if ($ein->titel == "Fraktion") $aliases[] = "fraktionen";
             if ($ein->titel == "Ausschuss") $aliases[] = "aussch&uuml;ssen";
 

--- a/protected/components/TermineCalDAVCalendarBackend.php
+++ b/protected/components/TermineCalDAVCalendarBackend.php
@@ -43,24 +43,24 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
     {
         /** @var Termin $termin */
         $termin = Termin::model()->findByPk($this->termin_id);
-        if (!$termin) return array();
+        if (!$termin) return [];
 
         list(, $name) = \Sabre\HTTP\URLUtil::splitPath($principalUri);
-        if ($name !== 'guest') return array();
+        if ($name !== 'guest') return [];
 
-        return array(
-            array(
+        return [
+            [
                 'id'                                                                        => $this->termin_id,
                 'uri'                                                                       => $this->termin_id,
                 'principaluri'                                                              => $principalUri,
                 '{DAV:}displayname'                                                         => $termin->gremium->getName(),
                 '{' . \Sabre\CalDAV\Plugin::NS_CALENDARSERVER . '}getctag'                  => rand(0, 100000000),
                 '{http://sabredav.org/ns}sync-token'                                        => '0',
-                '{' . \Sabre\CalDAV\Plugin::NS_CALDAV . '}supported-calendar-component-set' => new \Sabre\CalDAV\Property\SupportedCalendarComponentSet(array("VEVENT", "VJOURNAL", "VTODO")),
+                '{' . \Sabre\CalDAV\Plugin::NS_CALDAV . '}supported-calendar-component-set' => new \Sabre\CalDAV\Property\SupportedCalendarComponentSet(["VEVENT", "VJOURNAL", "VTODO"]),
                 '{' . \Sabre\CalDAV\Plugin::NS_CALDAV . '}schedule-calendar-transp'         => new \Sabre\CalDAV\Property\ScheduleCalendarTransp('opaque'),
                 '{http://sabredav.org/ns}read-only'                                         => '1',
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -152,9 +152,9 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
 
         $alle_termine = $termin->alleTermineDerReihe();
 
-        $dav_termine = array();
+        $dav_termine = [];
         foreach ($alle_termine as $akt_termin) {
-            $dav_termine[] = array(
+            $dav_termine[] = [
                 'id'           => $akt_termin->id,
                 'uri'          => $akt_termin->id,
                 'lastmodified' => $akt_termin->datum_letzte_aenderung,
@@ -162,7 +162,7 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
                 'calendarid'   => $calendarId,
                 'size'         => (int)10, // Dummywert
                 'component'    => 'VEVENT',
-            );
+            ];
         }
         return $dav_termine;
         /*
@@ -212,7 +212,7 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
         $calendardata = $vcalendar->serialize();
 
 
-        return array(
+        return [
             'id'           => $termin->id,
             'uri'          => $termin->id,
             'lastmodified' => $termin->datum_letzte_aenderung,
@@ -222,7 +222,7 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
             'calendardata' => $calendardata,
             'size'         => strlen($calendardata),
             'component'    => 'VEVENT',
-        );
+        ];
     }
 
     /**
@@ -240,7 +240,7 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
      */
     function getMultipleCalendarObjects($calendarId, array $uris)
     {
-        $return = array();
+        $return = [];
         foreach ($uris as $uri) {
             /** @var Termin $termin */
             $termin = Termin::model()->findByPk($uri);
@@ -250,7 +250,7 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
             $vcalendar->add('VEVENT', $termin->getVEventParams());
             $calendardata = $vcalendar->serialize();
 
-            $return[] = array(
+            $return[] = [
                 'id'           => $termin->id,
                 'uri'          => $termin->id,
                 'lastmodified' => $termin->datum_letzte_aenderung,
@@ -260,7 +260,7 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
                 'calendardata' => $calendardata,
                 'size'         => strlen($calendardata),
                 'component'    => 'VEVENT',
-            );
+            ];
         }
         return $return;
     }
@@ -382,7 +382,7 @@ class TermineCalDAVCalendarBackend implements Sabre\CalDAV\Backend\BackendInterf
         if (!$termin) throw new \Sabre\DAV\Exception\NotFound('Calendar not found');
 
         $alle_termine = $termin->alleTermineDerReihe();
-        $return       = array();
+        $return       = [];
         foreach ($alle_termine as $termin) {
             // @TODO Filtern
             $return[] = $termin->id;

--- a/protected/components/TermineCalDAVDebug.php
+++ b/protected/components/TermineCalDAVDebug.php
@@ -10,10 +10,10 @@ class TermineCalDAVDebug extends \Sabre\DAV\ServerPlugin {
 
 	protected $logLevel = 5;
 
-	protected $contentTypeWhiteList = array(
+	protected $contentTypeWhiteList = [
 		'|^text/|',
 		'|^application/xml|',
-	);
+	];
 
 	function __construct($logFile, $logLevel = 1) {
 		$this->logFile = $logFile;
@@ -40,10 +40,10 @@ class TermineCalDAVDebug extends \Sabre\DAV\ServerPlugin {
 	public function initialize(\Sabre\DAV\Server $server) {
 
 		$this->server = $server;
-		$this->server->on('beforeMethod', array($this, 'beforeMethod'), 5);
-		$this->server->on('unknownMethod', array($this, 'unknownMethod'), 5);
-		$this->server->on('report', array($this, 'report'), 5);
-		$this->server->on('beforeGetProperties', array($this, 'beforeGetProperties'), 5);
+		$this->server->on('beforeMethod', [$this, 'beforeMethod'], 5);
+		$this->server->on('unknownMethod', [$this, 'unknownMethod'], 5);
+		$this->server->on('report', [$this, 'report'], 5);
+		$this->server->on('beforeGetProperties', [$this, 'beforeGetProperties'], 5);
 		$this->log(2,'Initialized plugin. Request time ' . $this->startTime . ' (' . date(\DateTime::RFC2822,$this->startTime) . '). Version: ' . \Sabre\DAV\Version::VERSION);
 
 	}

--- a/protected/components/TermineCalDAVPrincipalBackend.php
+++ b/protected/components/TermineCalDAVPrincipalBackend.php
@@ -15,22 +15,22 @@ class TermineCalDAVPrincipalBackend extends Sabre\DAVACL\PrincipalBackend\Abstra
 
     public function getPrincipalsByPrefix($prefixPath)
     {
-        $base = YII::app()->createUrl("termine/dav", array("termin_id" => $this->termin_id));
-        return array(
-            array(
+        $base = YII::app()->createUrl("termine/dav", ["termin_id" => $this->termin_id]);
+        return [
+            [
                 '{DAV:}displayname' => 'Gast',
                 'uri'               => "principals/guest",
-            ),
-        );
+            ],
+        ];
     }
 
     public function getPrincipalByPath($path)
     {
-        $base = YII::app()->createUrl("termine/dav", array("termin_id" => $this->termin_id));
-        if ($path == 'principals/guest') return array(
+        $base = YII::app()->createUrl("termine/dav", ["termin_id" => $this->termin_id]);
+        if ($path == 'principals/guest') return [
             '{DAV:}displayname' => 'Gast',
             'uri'               => "principals/guest",
-        );
+        ];
         return null;
     }
 
@@ -47,14 +47,14 @@ class TermineCalDAVPrincipalBackend extends Sabre\DAVACL\PrincipalBackend\Abstra
     public function getGroupMemberSet($principal)
     {
         // not implemented, this could return all principals for a share-all calendar server
-        return array();
+        return [];
     }
 
     public function getGroupMembership($principal)
     {
         // not implemented, this could return a list of all principals
         // with two subprincipals: calendar-proxy-read and calendar-proxy-write for a share-all calendar server
-        return array();
+        return [];
 
     }
 

--- a/protected/config/main.template.php
+++ b/protected/config/main.template.php
@@ -57,7 +57,7 @@ $GLOBALS["SOLR_CONFIG"] = array(
 
 function ris_intern_address2geo($land, $plz, $ort, $strasse)
 {
-    return array("lon" => 0, "lat" => 0);
+    return ["lon" => 0, "lat" => 0];
 }
 
 
@@ -113,44 +113,44 @@ function ris_intern_html_extra_headers()
 
 // This is the main Web application configuration. Any writable
 // CWebApplication properties can be configured here.
-return array(
+return [
     'basePath'       => dirname(__FILE__) . DIRECTORY_SEPARATOR . '..',
     'name'           => 'München Transparent',
 
     // preloading 'log' component
-    'preload'        => array('log'),
+    'preload'        => ['log'],
 
     // autoloading model and component classes
-    'import'         => array(
+    'import'         => [
         'application.models.*',
         'application.components.*',
         'application.RISParser.*',
-    ),
+    ],
 
     'onBeginRequest' => create_function('$event', 'if (SITE_CALL_MODE == "web") return ob_start("ob_gzhandler");'),
     'onEndRequest'   => create_function('$event', 'if (SITE_CALL_MODE == "web") return ob_end_flush();'),
 
-    'modules'        => array(
+    'modules'        => [
         // uncomment the following to enable the Gii tool
-        'gii' => array(
+        'gii' => [
             'class'    => 'system.gii.GiiModule',
             'password' => 'RANDOMKEY',
             // If removed, Gii defaults to localhost only. Edit carefully to taste.
             //'ipFilters' => array('*', '::1'),
-        ),
-    ),
+        ],
+    ],
 
     // application components
-    'components'     => array(
-        'cache'        => array(
+    'components'     => [
+        'cache'        => [
             'class' => 'system.caching.CFileCache',
-        ),
-        'urlManager'   => array(
+        ],
+        'urlManager'   => [
             'urlFormat'      => 'path',
             'showScriptName' => false,
             'rules'          => $GLOBALS["RIS_URL_RULES"],
-        ),
-        'db'           => array(
+        ],
+        'db'           => [
             'connectionString'      => 'mysql:host=127.0.0.1;dbname=DB',
             'emulatePrepare'        => true,
             'username'              => 'ris',
@@ -158,30 +158,30 @@ return array(
             'charset'               => 'utf8mb4',
             'queryCacheID'          => 'apcCache',
             'schemaCachingDuration' => 3600,
-        ),
-        'errorHandler' => array(
+        ],
+        'errorHandler' => [
             // use 'site/error' action to display errors
             'errorAction' => 'index/error',
-        ),
-        'log'          => array(
+        ],
+        'log'          => [
             'class'  => 'CLogRouter',
-            'routes' => array(
-                array(
+            'routes' => [
+                [
                     'class'  => 'CFileLogRoute',
                     'levels' => 'error, warning',
-                ),
+                ],
                 /*
                 array(
                     'class' => 'CWebLogRoute',
                 ),
                 */
-            ),
-        ),
-    ),
+            ],
+        ],
+    ],
 
     // application-level parameters that can be accessed
     // using Yii::app()->params['paramName']
-    'params'         => array(
+    'params'         => [
         // this is used in contact page
         'adminEmail'          => 'info@muenchen-transparent.de',
         'adminEmailName'      => "München Transparent",
@@ -191,5 +191,5 @@ return array(
         'projectTitle'        => 'München Transparent',
         'startseiten_warnung' => '',
         'concatScripts'       => false,
-    ),
-);
+    ],
+];

--- a/protected/config/test.php
+++ b/protected/config/test.php
@@ -2,16 +2,16 @@
 
 return CMap::mergeArray(
     require(dirname(__FILE__) . '/main.php'),
-    array(
-        'components' => array(
-            'fixture' => array(
+    [
+        'components' => [
+            'fixture' => [
                 'class' => 'system.test.CDbFixtureManager',
-            ),
+            ],
             /* uncomment the following to provide test database connection
             'db'=>array(
                 'connectionString'=>'DSN for test database',
             ),
             */
-        ),
-    )
+        ],
+    ]
 );

--- a/protected/config/urls.php
+++ b/protected/config/urls.php
@@ -1,6 +1,6 @@
 <?php
 
-$GLOBALS["RIS_URL_RULES"] = array(
+$GLOBALS["RIS_URL_RULES"] = [
     SITE_BASE_URL . '/'                                                 => 'index/startseite',
     SITE_BASE_URL . '/ajax-<datum_max:[0-9\-]+>'                        => 'index/antraegeAjax',
     SITE_BASE_URL . '/bezirksausschuss'                                 => 'index/baListe',
@@ -33,4 +33,4 @@ $GLOBALS["RIS_URL_RULES"] = array(
     SITE_BASE_URL . '/<controller:\w+>/<id:\d+>'                        => '<controller>/anzeigen',
     SITE_BASE_URL . '/<controller:\w+>/<action:\w+>/<id:\d+>'           => '<controller>/<action>',
     SITE_BASE_URL . '/<controller:\w+>/<action:\w+>'                    => '<controller>/<action>',
-);
+];

--- a/protected/controllers/AdminController.php
+++ b/protected/controllers/AdminController.php
@@ -25,15 +25,15 @@ class AdminController extends RISBaseController
         }
 
         /** @var Person[] $personen */
-        $personen = Person::model()->findAll(array("order" => "name"));
+        $personen = Person::model()->findAll(["order" => "name"]);
 
         /** @var StadtraetIn[] $stadtraetInnen */
-        $stadtraetInnen = StadtraetIn::model()->findAll(array("order" => "name"));
+        $stadtraetInnen = StadtraetIn::model()->findAll(["order" => "name"]);
 
-        $this->render("stadtraetInnenPersonen", array(
+        $this->render("stadtraetInnenPersonen", [
             "personen"       => $personen,
             "stadtraetInnen" => $stadtraetInnen,
-        ));
+        ]);
     }
 
 
@@ -59,9 +59,9 @@ class AdminController extends RISBaseController
         /** @var array[] $fraktionen */
         $fraktionen = StadtraetIn::getGroupedByFraktion(date("Y-m-d"), null);
 
-        $this->render("stadtraetInnenSocialMedia", array(
+        $this->render("stadtraetInnenSocialMedia", [
             "fraktionen" => $fraktionen,
-        ));
+        ]);
     }
 
 
@@ -87,9 +87,9 @@ class AdminController extends RISBaseController
         /** @var array[] $fraktionen */
         $fraktionen = StadtraetIn::getGroupedByFraktion(date("Y-m-d"), null);
 
-        $this->render("stadtraetInnenBeschreibungen", array(
+        $this->render("stadtraetInnenBeschreibungen", [
             "fraktionen" => $fraktionen,
-        ));
+        ]);
     }
 
     public function actionStadtraetInnenBenutzerInnen()
@@ -115,9 +115,9 @@ class AdminController extends RISBaseController
         $stadtraetInnen = StadtraetIn::model()->findAll();
         $stadtraetInnen = StadtraetIn::sortByName($stadtraetInnen);
 
-        $this->render("stadtraetInnenBenutzerInnen", array(
+        $this->render("stadtraetInnenBenutzerInnen", [
             "stadtraetInnen" => $stadtraetInnen,
-        ));
+        ]);
     }
 
 
@@ -138,17 +138,17 @@ class AdminController extends RISBaseController
         $this->top_menu = "admin";
 
         if (AntiXSS::isTokenSet("tag_umbennen")) {
-            $tag_alt     = Tag::model()->findByAttributes(array("id" => $_REQUEST["tag_id"]));
-            $gleichnamig = Tag::model()->findByAttributes(array("name" => $_REQUEST["neuer_name"]));
+            $tag_alt     = Tag::model()->findByAttributes(["id" => $_REQUEST["tag_id"]]);
+            $gleichnamig = Tag::model()->findByAttributes(["name" => $_REQUEST["neuer_name"]]);
 
             if ($gleichnamig != null) { // Tag mit neuem Namen existiert bereits-> merge
                 // Zuerst bei allen Anträgen mit beiden tags den Eintrag für den alten tag löschen
                 Yii::app()->db->createCommand('DELETE t1 FROM antraege_tags t1 INNER JOIN antraege_tags t2 ON t1.antrag_id=t2.antrag_id WHERE t1.tag_id=:tag_id_alt AND t2.tag_id=:tag_id_neu')
-                    ->bindValues(array(':tag_id_neu' => $gleichnamig->id, ':tag_id_alt' => $tag_alt->id))
+                    ->bindValues([':tag_id_neu' => $gleichnamig->id, ':tag_id_alt' => $tag_alt->id])
                     ->execute();
 
                 Yii::app()->db->createCommand('UPDATE antraege_tags SET tag_id=:tag_id_neu WHERE tag_id=:tag_id_alt')
-                    ->bindValues(array(':tag_id_neu' => $gleichnamig->id, ':tag_id_alt' => $tag_alt->id))
+                    ->bindValues([':tag_id_neu' => $gleichnamig->id, ':tag_id_alt' => $tag_alt->id])
                     ->execute();
 
                 $tag_alt->delete();
@@ -163,10 +163,10 @@ class AdminController extends RISBaseController
         }
 
         if (AntiXSS::isTokenSet("tag_loeschen")) {
-            $tag = Tag::model()->findByAttributes(array("id" => $_REQUEST["tag_id"]));
+            $tag = Tag::model()->findByAttributes(["id" => $_REQUEST["tag_id"]]);
 
             Yii::app()->db->createCommand('DELETE FROM antraege_tags WHERE tag_id=:tag_id')
-                ->bindValues(array(':tag_id' => $tag->id))
+                ->bindValues([':tag_id' => $tag->id])
                 ->execute();
 
             $tag->delete();
@@ -175,10 +175,10 @@ class AdminController extends RISBaseController
         }
 
         if (AntiXSS::isTokenSet("einzelnen_tag_loeschen")) {
-            $tag = Tag::model()->findByAttributes(array("name" => $_REQUEST["tag_name"]));
+            $tag = Tag::model()->findByAttributes(["name" => $_REQUEST["tag_name"]]);
 
             Yii::app()->db->createCommand('DELETE FROM antraege_tags WHERE tag_id=:tag_id AND antrag_id=:antrag_id')
-                ->bindValues(array(':tag_id' => $tag->id, ':antrag_id' => $_REQUEST["antrag_id"]))
+                ->bindValues([':tag_id' => $tag->id, ':antrag_id' => $_REQUEST["antrag_id"]])
                 ->execute();
 
             $this->msg_ok = "Einzelner Tag gelöscht";
@@ -198,9 +198,9 @@ class AdminController extends RISBaseController
             return ($name1 > $name2) ? +1 : -1;
         });
 
-        $this->render("tags", array(
+        $this->render("tags", [
             "tags" => $tags,
-        ));
+        ]);
     }
 
     public function actionBuergerInnenversammlungen()
@@ -244,9 +244,9 @@ class AdminController extends RISBaseController
             $this->msg_ok = "Gespeichert";
         }
 
-        $termine = Termin::model()->findAllByAttributes(array("typ" => Termin::$TYP_BV), array("order" => "termin DESC"));
-        $this->render("buergerInnenversammlungen", array(
+        $termine = Termin::model()->findAllByAttributes(["typ" => Termin::$TYP_BV], ["order" => "termin DESC"]);
+        $this->render("buergerInnenversammlungen", [
             "termine" => $termine,
-        ));
+        ]);
     }
 }

--- a/protected/controllers/AntraegeController.php
+++ b/protected/controllers/AntraegeController.php
@@ -7,8 +7,8 @@ class AntraegeController extends RISBaseController
     {
         $sqlterm = addslashes($term);
         $found   = Yii::app()->db->createCommand("SELECT id, name, LOCATE(\"$sqlterm\", name) firstpos FROM tags WHERE name LIKE \"%$sqlterm%\" ORDER BY firstpos, LENGTH(name), name LIMIT 0,10")->queryAll();
-        $tags    = array();
-        foreach ($found as $f) $tags[] = array("text" => $f["name"], "value" => $f["name"]);
+        $tags    = [];
+        foreach ($found as $f) $tags[] = ["text" => $f["name"], "value" => $f["name"]];
         header('Content-type: application/json; charset=UTF-8');
         echo json_encode($tags);
     }
@@ -21,13 +21,13 @@ class AntraegeController extends RISBaseController
         /** @var Antrag $antrag */
         $antrag = Antrag::model()->findByPk($id);
         if (!$antrag) {
-            $this->render('/index/error', array("code" => 404, "message" => "Der Antrag wurde nicht gefunden"));
+            $this->render('/index/error', ["code" => 404, "message" => "Der Antrag wurde nicht gefunden"]);
             return;
         }
 
-        $this->render("related_list", array(
+        $this->render("related_list", [
             "related" => $antrag->errateThemenverwandteAntraege(10),
-        ));
+        ]);
     }
 
     /**
@@ -38,12 +38,12 @@ class AntraegeController extends RISBaseController
         /** @var Antrag $antrag */
         $antrag = Antrag::model()->findByPk($id);
         if (!$antrag) {
-            $this->render('/index/error', array("code" => 404, "message" => "Der Antrag wurde nicht gefunden"));
+            $this->render('/index/error', ["code" => 404, "message" => "Der Antrag wurde nicht gefunden"]);
             return;
         }
-        $this->render("themenverwandte", array(
+        $this->render("themenverwandte", [
             "antrag" => $antrag,
-        ));
+        ]);
     }
 
     /**
@@ -56,17 +56,17 @@ class AntraegeController extends RISBaseController
         /** @var Antrag $antrag */
         $antrag = Antrag::model()->findByPk($id);
         if (!$antrag) {
-            $this->render('/index/error', array("code" => 404, "message" => "Der Antrag wurde nicht gefunden"));
+            $this->render('/index/error', ["code" => 404, "message" => "Der Antrag wurde nicht gefunden"]);
             return;
         }
 
         if (AntiXSS::isTokenSet("abonnieren")) {
-            $this->requireLogin($this->createUrl("antraege/anzeigen", array("id" => $id)));
+            $this->requireLogin($this->createUrl("antraege/anzeigen", ["id" => $id]));
             $antrag->getVorgang()->abonnieren($this->aktuelleBenutzerIn());
         }
 
         if (AntiXSS::isTokenSet("deabonnieren")) {
-            $this->requireLogin($this->createUrl("antraege/anzeigen", array("id" => $id)));
+            $this->requireLogin($this->createUrl("antraege/anzeigen", ["id" => $id]));
             $antrag->getVorgang()->deabonnieren($this->aktuelleBenutzerIn());
         }
 
@@ -75,7 +75,7 @@ class AntraegeController extends RISBaseController
 
             foreach ($tags as $tag_name) if (mb_strlen(trim($tag_name)) > 0) try {
                 $tag_name = trim($tag_name);
-                $tag      = Tag::model()->findByAttributes(array("name" => $tag_name));
+                $tag      = Tag::model()->findByAttributes(["name" => $tag_name]);
                 if (!$tag) {
                     $tag                         = new Tag();
                     $tag->name                   = $tag_name;
@@ -85,22 +85,22 @@ class AntraegeController extends RISBaseController
                     $tag->save();
 
                     if (count($tag->getErrors()) > 0) {
-                        $this->render('/index/error', array("code" => 500, "message" => "Ein Fehler beim Anlegen des Schlagworts trat auf"));
+                        $this->render('/index/error', ["code" => 500, "message" => "Ein Fehler beim Anlegen des Schlagworts trat auf"]);
                     }
                 }
 
-                Yii::app()->db->createCommand()->insert("antraege_tags", array(
+                Yii::app()->db->createCommand()->insert("antraege_tags", [
                     "antrag_id" => $antrag->id, "tag_id" => $tag->id, "zugeordnet_datum" => date("Y-m-d H:i:s"), "zugeordnet_benutzerIn_id" => $this->aktuelleBenutzerIn()->id
-                ));
+                ]);
             } catch (Exception $e) {
                 // Sind hauptsächlich doppelte Einträge -> ignorieren
             }
         }
 
-        $this->render("anzeige", array(
+        $this->render("anzeige", [
             "antrag"   => $antrag,
             "tag_mode" => (isset($_REQUEST["tag_mode"]) && $_REQUEST["tag_mode"] == "1"),
-        ));
+        ]);
     }
 
 }

--- a/protected/controllers/BenachrichtigungenController.php
+++ b/protected/controllers/BenachrichtigungenController.php
@@ -92,7 +92,7 @@ class BenachrichtigungenController extends RISBaseController
 
                 Yii::app()->db
                     ->createCommand("DELETE FROM `benutzerInnen_vorgaenge_abos` WHERE `benutzerInnen_id` = :BenutzerInId")
-                    ->bindValues(array(':BenutzerInId' => $ich->id))
+                    ->bindValues([':BenutzerInId' => $ich->id])
                     ->execute();
 
                 $this->msg_ok = "Account gelöscht";
@@ -121,13 +121,13 @@ class BenachrichtigungenController extends RISBaseController
                     $this->msg_err = "Die beiden Passwörter stimmen nicht überein";
                 }
             } else {
-                $this->render('/index/error', array("code" => 403, "message" => "Sie sind nicht angemeldet."));
+                $this->render('/index/error', ["code" => 403, "message" => "Sie sind nicht angemeldet."]);
             }
         }
 
-        $this->render("index", array(
+        $this->render("index", [
             "ich" => $ich,
-        ));
+        ]);
     }
 
     /**
@@ -148,7 +148,7 @@ class BenachrichtigungenController extends RISBaseController
         $dismax->setQueryFields("text text_ocr");
 
         $benachrichtigungen = $benutzerIn->getBenachrichtigungen();
-        $krits_solr         = array();
+        $krits_solr         = [];
 
         foreach ($benachrichtigungen as $ben) $krits_solr[] = "(" . $ben->getSolrQueryStr($select) . ")";
         $querystr = implode(" OR ", $krits_solr);
@@ -171,7 +171,7 @@ class BenachrichtigungenController extends RISBaseController
     {
         $benutzerIn = BenutzerIn::getByFeedCode($code);
         if (!$benutzerIn) {
-            $this->render('../index/error', array("code" => 400, "message" => "Das Feed konnte leider nicht gefunden werden."));
+            $this->render('../index/error', ["code" => 400, "message" => "Das Feed konnte leider nicht gefunden werden."]);
             return;
         }
 
@@ -185,11 +185,11 @@ class BenachrichtigungenController extends RISBaseController
         $ergebnisse = $solr->select($select);
         $data       = RISSolrHelper::ergebnisse2FeedData($ergebnisse);
 
-        $this->render("../index/feed", array(
+        $this->render("../index/feed", [
             "feed_title"       => $titel,
             "feed_description" => $description,
             "data"             => $data,
-        ));
+        ]);
 
     }
 
@@ -211,9 +211,9 @@ class BenachrichtigungenController extends RISBaseController
         $ergebnisse = $solr->select($select);
 
 
-        $this->render("alle_suchergebnisse", array(
+        $this->render("alle_suchergebnisse", [
             "ergebnisse" => $ergebnisse,
-        ));
+        ]);
     }
 
 
@@ -232,7 +232,7 @@ class BenachrichtigungenController extends RISBaseController
     {
         if (AntiXSS::isTokenSet("reset_password")) {
             /** @var null|BenutzerIn $benutzerIn */
-            $benutzerIn = BenutzerIn::model()->findByAttributes(array("email" => $_REQUEST["email"]));
+            $benutzerIn = BenutzerIn::model()->findByAttributes(["email" => $_REQUEST["email"]]);
             if ($benutzerIn) {
                 $ret = $benutzerIn->resetPasswordStart();
                 if ($ret === true) {
@@ -256,24 +256,24 @@ class BenachrichtigungenController extends RISBaseController
     */
     public function actionNeuesPasswortSetzen($id = "", $code = "")
     {
-        $my_url = $this->createUrl("benachrichtigungen/NeuesPasswortSetzen", array("id" => $id, "code" => $code));
+        $my_url = $this->createUrl("benachrichtigungen/NeuesPasswortSetzen", ["id" => $id, "code" => $code]);
         if (AntiXSS::isTokenSet("reset_password")) {
             /** @var null|BenutzerIn $benutzerIn */
             $benutzerIn = BenutzerIn::model()->findByPk($id);
 
             if (!$benutzerIn) {
                 $this->msg_err = "BenutzerIn nicht gefunden";
-                $this->render('reset_password_form', array(
+                $this->render('reset_password_form', [
                     "current_url" => $this->createUrl("benachrichtigungen/PasswortZuruecksetzen"),
-                ));
+                ]);
                 return;
             }
 
             if ($_REQUEST["password"] != $_REQUEST["password2"]) {
                 $this->msg_err = "Die beiden Passwörter stimmen nicht überein";
-                $this->render('reset_password_set_form', array(
+                $this->render('reset_password_set_form', [
                     "current_url" => $my_url,
-                ));
+                ]);
                 return;
             }
 
@@ -282,14 +282,14 @@ class BenachrichtigungenController extends RISBaseController
                 $this->render('reset_password_done');
             } else {
                 $this->msg_err = $ret;
-                $this->render('reset_password_set_form', array(
+                $this->render('reset_password_set_form', [
                     "current_url" => $my_url,
-                ));
+                ]);
             }
         } else {
-            $this->render('reset_password_set_form', array(
+            $this->render('reset_password_set_form', [
                 "current_url" => $my_url,
-            ));
+            ]);
         }
     }
 

--- a/protected/controllers/IndexController.php
+++ b/protected/controllers/IndexController.php
@@ -14,17 +14,17 @@ class IndexController extends RISBaseController
     {
 
         if ($width == 256) {
-            $boundaries = array(
-                3  => array(2, 2, 6, 3),
-                4  => array(6, 4, 11, 6),
-                5  => array(14, 10, 19, 11),
-                6  => array(31, 21, 36, 22),
-                7  => array(66, 43, 70, 45),
-                8  => array(134, 88, 138, 89),
-                9  => array(270, 176, 274, 178),
-                10 => array(542, 354, 547, 356),
-                11 => array(1086, 708, 1091, 712),
-            );
+            $boundaries = [
+                3  => [2, 2, 6, 3],
+                4  => [6, 4, 11, 6],
+                5  => [14, 10, 19, 11],
+                6  => [31, 21, 36, 22],
+                7  => [66, 43, 70, 45],
+                8  => [134, 88, 138, 89],
+                9  => [270, 176, 274, 178],
+                10 => [542, 354, 547, 356],
+                11 => [1086, 708, 1091, 712],
+            ];
             if (isset($boundaries[$zoom])) {
                 $bound       = $boundaries[$zoom];
                 $outofbounds = false;
@@ -38,11 +38,11 @@ class IndexController extends RISBaseController
         }
 
         if ($width == 256) {
-            $array = array("1", "2", "3");
+            $array = ["1", "2", "3"];
             $key   = $array[array_rand($array)] . "-" . Yii::app()->params['skobblerKey'];
             $url   = "http://tiles" . $key . ".skobblermaps.com/TileService/tiles/2.0/00022210100/0/${zoom}/${x}/${y}.png";
         } else {
-            $array = array("1", "2", "3");
+            $array = ["1", "2", "3"];
             $key   = $array[array_rand($array)] . "-" . Yii::app()->params['skobblerKey'];
             $url   = "http://tiles" . $key . ".skobblermaps.com/TileService/tiles/2.0/00022210100/0/${zoom}/${x}/${y}.png@2x";
         }
@@ -103,18 +103,18 @@ class IndexController extends RISBaseController
 
             $data = RISSolrHelper::ergebnisse2FeedData($ergebnisse);
         } else {
-            $data = array();
+            $data = [];
             /** @var array|RISAenderung[] $aenderungen */
-            $aenderungen = RISAenderung::model()->findAll(array("order" => "id DESC", "limit" => 100));
+            $aenderungen = RISAenderung::model()->findAll(["order" => "id DESC", "limit" => 100]);
             foreach ($aenderungen as $aenderung) $data[] = $aenderung->toFeedData();
             $titel = Yii::app()->params['projectTitle'] . ' Änderungen';
         }
 
-        $this->render("feed", array(
+        $this->render("feed", [
             "feed_title"       => $titel,
             "feed_description" => $titel,
             "data"             => $data,
-        ));
+        ]);
     }
 
     /**
@@ -136,7 +136,7 @@ class IndexController extends RISBaseController
 
         if (!$user->isGuest) {
             /** @var BenutzerIn $ich */
-            $ich = BenutzerIn::model()->findByAttributes(array("email" => Yii::app()->user->id));
+            $ich = BenutzerIn::model()->findByAttributes(["email" => Yii::app()->user->id]);
 
             if ($do_benachrichtigung_add) {
                 $ich->addBenachrichtigung($curr_krits);
@@ -159,7 +159,7 @@ class IndexController extends RISBaseController
         } else {
             $eingeloggt = true;
             /** @var BenutzerIn $ich */
-            if (!$ich) $ich = BenutzerIn::model()->findByAttributes(array("email" => Yii::app()->user->id));
+            if (!$ich) $ich = BenutzerIn::model()->findByAttributes(["email" => Yii::app()->user->id]);
             if ($ich->email == "") {
                 $email_angegeben  = false;
                 $email_bestaetigt = false;
@@ -172,13 +172,13 @@ class IndexController extends RISBaseController
             }
         }
 
-        return array(
+        return [
             "eingeloggt"          => $eingeloggt,
             "email_angegeben"     => $email_angegeben,
             "email_bestaetigt"    => $email_bestaetigt,
             "wird_benachrichtigt" => $wird_benachrichtigt,
             "ich"                 => $ich,
-        );
+        ];
     }
 
 
@@ -189,7 +189,7 @@ class IndexController extends RISBaseController
      */
     protected function dokumente2geodata(&$dokumente, $filter_krits = null)
     {
-        $geodata = array();
+        $geodata = [];
         foreach ($dokumente as $dokument) {
             if ($dokument->antrag) {
                 $link = $dokument->antrag->getLink();
@@ -206,13 +206,13 @@ class IndexController extends RISBaseController
                 $str = $link;
                 $str .= "<div class='ort_dokument'>";
                 $str .= "<div class='ort'>" . CHtml::encode($ort->ort->ort) . "</div>";
-                $str .= "<div class='dokument'>" . CHtml::link($dokument->name, $this->createUrl("index/dokument", array("id" => $dokument->id))) . "</div>";
+                $str .= "<div class='dokument'>" . CHtml::link($dokument->name, $this->createUrl("index/dokument", ["id" => $dokument->id])) . "</div>";
                 $str .= "</div>";
-                $geodata[] = array(
+                $geodata[] = [
                     FloatVal($ort->ort->lat),
                     FloatVal($ort->ort->lon),
                     $str
-                );
+                ];
             }
         }
         return $geodata;
@@ -228,12 +228,12 @@ class IndexController extends RISBaseController
         $geo = $krits->getGeoKrit();
         /** @var RISSolrDocument[] $solr_dokumente */
         $solr_dokumente = $ergebnisse->getDocuments();
-        $dokument_ids   = array();
+        $dokument_ids   = [];
         foreach ($solr_dokumente as $dokument) {
             $x              = explode(":", $dokument->id);
             $dokument_ids[] = IntVal($x[1]);
         }
-        $geodata = array();
+        $geodata = [];
         if (count($dokument_ids) > 0) {
             $lat        = FloatVal($geo["lat"]);
             $lng        = FloatVal($geo["lng"]);
@@ -258,13 +258,13 @@ class IndexController extends RISBaseController
                 $str = $link;
                 $str .= "<div class='ort_dokument'>";
                 $str .= "<div class='ort'>" . CHtml::encode($geo["ort"]) . "</div>";
-                $str .= "<div class='dokument'>" . CHtml::link($dokument->name, $this->createUrl("index/dokument", array("id" => $dokument->id))) . "</div>";
+                $str .= "<div class='dokument'>" . CHtml::link($dokument->name, $this->createUrl("index/dokument", ["id" => $dokument->id])) . "</div>";
                 $str .= "</div>";
-                $geodata[] = array(
+                $geodata[] = [
                     FloatVal($geo["lat"]),
                     FloatVal($geo["lon"]),
                     $str
-                );
+                ];
             }
 
         }
@@ -279,8 +279,8 @@ class IndexController extends RISBaseController
      */
     protected function antraege2geodata(&$antraege, $typ = 0)
     {
-        $geodata          = $geodata_overflow = array();
-        $geodata_nach_dok = array();
+        $geodata          = $geodata_overflow = [];
+        $geodata_nach_dok = [];
         foreach ($antraege as $ant) {
             foreach ($ant->dokumente as $dokument) {
                 foreach ($dokument->orte as $ort) if ($ort->ort->to_hide == 0) {
@@ -293,13 +293,13 @@ class IndexController extends RISBaseController
                     $str .= "</div>";
                     $str = mb_convert_encoding($str, 'UTF-8', 'UTF-8');
 
-                    if (!isset($geodata_nach_dok[$dokument->id])) $geodata_nach_dok[$dokument->id] = array();
-                    $geodata_nach_dok[$dokument->id][] = array(
+                    if (!isset($geodata_nach_dok[$dokument->id])) $geodata_nach_dok[$dokument->id] = [];
+                    $geodata_nach_dok[$dokument->id][] = [
                         FloatVal($ort->ort->lat),
                         FloatVal($ort->ort->lon),
                         $str,
                         $typ
-                    );
+                    ];
                 }
             }
         }
@@ -309,7 +309,7 @@ class IndexController extends RISBaseController
             foreach ($dok_geo as $d) $geodata[] = $d;
         }
 
-        return array($geodata, $geodata_overflow);
+        return [$geodata, $geodata_overflow];
     }
 
     /**
@@ -320,9 +320,9 @@ class IndexController extends RISBaseController
     {
         Header("Content-Type: application/json; charset=UTF-8");
         $naechster_ort = OrtGeo::findClosest($lng, $lat);
-        echo json_encode(array(
+        echo json_encode([
             "ort_name" => $naechster_ort->ort,
-        ));
+        ]);
         Yii::app()->end();
     }
 
@@ -350,23 +350,23 @@ class IndexController extends RISBaseController
         $ergebnisse = $solr->select($select);
 
         /** @var Antrag[] $antraege */
-        $antraege = array();
+        $antraege = [];
         /** @var RISSolrDocument[] $solr_dokumente */
         $solr_dokumente = $ergebnisse->getDocuments();
-        $dokument_ids   = array();
+        $dokument_ids   = [];
         foreach ($solr_dokumente as $dokument) {
             $x              = explode(":", $dokument->id);
             $dokument_ids[] = IntVal($x[1]);
         }
         foreach ($dokument_ids as $dok_id) {
             /** @var Dokument $ant */
-            $ant = Dokument::model()->with(array(
-                "antrag"           => array(),
-                "antrag.dokumente" => array(
+            $ant = Dokument::model()->with([
+                "antrag"           => [],
+                "antrag.dokumente" => [
                     "alias"     => "dokumente_2",
                     "condition" => "dokumente_2.id IN (" . implode(", ", $dokument_ids) . ")"
-                )
-            ))->findByPk($dok_id);
+                ]
+            ])->findByPk($dok_id);
             if ($ant && $ant->antrag) {
                 $antraege[$ant->antrag_id] = $ant->antrag;
             }
@@ -376,9 +376,9 @@ class IndexController extends RISBaseController
         $naechster_ort = OrtGeo::findClosest($lng, $lat);
         ob_start();
 
-        $this->renderPartial('index_antraege_liste', array(
-            "aeltere_url_ajax"  => $this->createUrl("index/antraegeAjaxGeo", array("lat" => $lat, "lng" => $lng, "radius" => $radius, "seite" => ($seite + 1))),
-            "aeltere_url_std"   => $this->createUrl("index/antraegeStdGeo", array("lat" => $lat, "lng" => $lng, "radius" => $radius, "seite" => ($seite + 1))),
+        $this->renderPartial('index_antraege_liste', [
+            "aeltere_url_ajax"  => $this->createUrl("index/antraegeAjaxGeo", ["lat" => $lat, "lng" => $lng, "radius" => $radius, "seite" => ($seite + 1)]),
+            "aeltere_url_std"   => $this->createUrl("index/antraegeStdGeo", ["lat" => $lat, "lng" => $lng, "radius" => $radius, "seite" => ($seite + 1)]),
             "neuere_url_ajax"   => null,
             "neuere_url_std"    => null,
             "antraege"          => $antraege,
@@ -388,16 +388,16 @@ class IndexController extends RISBaseController
             "naechster_ort"     => $naechster_ort,
             "weiter_links_oben" => true,
             "zeige_jahr"        => true,
-        ));
+        ]);
 
         Header("Content-Type: application/json; charset=UTF-8");
-        echo json_encode(array(
+        echo json_encode([
             "datum"         => date("Y-m-d"),
             "html"          => ob_get_clean(),
             "geodata"       => $geodata,
             "krit_str"      => $krits->getJson(),
             "naechster_ort" => $naechster_ort->ort
-        ));
+        ]);
         Yii::app()->end();
     }
 
@@ -427,7 +427,7 @@ class IndexController extends RISBaseController
 
         } elseif (isset($_REQUEST["suchbegriff"]) && $_REQUEST["suchbegriff"] != "") {
             $suchbegriff = $_REQUEST["suchbegriff"];
-            if ($_SERVER["REQUEST_METHOD"] == 'POST') $this->redirect($this->createUrl("index/suche", array("suchbegriff" => $suchbegriff)));
+            if ($_SERVER["REQUEST_METHOD"] == 'POST') $this->redirect($this->createUrl("index/suche", ["suchbegriff" => $suchbegriff]));
             $this->suche_pre = $suchbegriff;
             $krits           = new RISSucheKrits();
             $krits->addVolltextsucheKrit($suchbegriff);
@@ -467,13 +467,13 @@ class IndexController extends RISBaseController
                 if ($krits->isGeoKrit()) $geodata = $this->getJSGeodata($krits, $ergebnisse);
                 else $geodata = null;
 
-                $this->render("suchergebnisse", array_merge(array(
+                $this->render("suchergebnisse", array_merge([
                     "krits"      => $krits,
                     "ergebnisse" => $ergebnisse,
                     "geodata"    => $geodata,
-                ), $benachrichtigungen_optionen));
+                ], $benachrichtigungen_optionen));
             } catch (Exception $e) {
-                $this->render('error', array("code" => 500, "message" => "Ein Fehler bei der Suche ist aufgetreten"));
+                $this->render('error', ["code" => 500, "message" => "Ein Fehler bei der Suche ist aufgetreten"]);
                 Yii::app()->end(500);
             }
         } else {
@@ -516,7 +516,7 @@ class IndexController extends RISBaseController
 
         if (preg_match("/^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$/siu", $datum_max)) {
 	    if ($datum_max < 2013) {
-                return array(); // Überlastung des Servers verhindertn
+                return []; // Überlastung des Servers verhindertn
 	    }
             $datum_bis = $datum_max;
             $datum_von = date("Y-m-d", RISTools::date_iso2timestamp($datum_max) - $tage * 24 * 3600);
@@ -531,7 +531,7 @@ class IndexController extends RISBaseController
         $antraege2 = Antrag::model()->neueste_stadtratsantragsdokumente_geo($ba_nr, $datum_von . " 00:00:00", $datum_bis . " 23:59:59")->findAll();
 
         $antraege = $antraege1;
-        $a_ids    = array();
+        $a_ids    = [];
         foreach ($antraege1 as $a) $a_ids[] = $a->id;
         foreach ($antraege2 as $a) if (!in_array($a->id, $a_ids)) $antraege[] = $a;
         usort($antraege, function ($a1, $a2) {
@@ -549,9 +549,9 @@ class IndexController extends RISBaseController
         $geodata          = array_merge($geodata1, $geodata2);
         $geodata_overflow = array_merge($geodata_overflow1, $geodata_overflow2);
 
-        $aeltere_url_std  = $this->createUrl("index/baDokumente", array("ba_nr" => $ba_nr, "datum_max" => date("Y-m-d", RISTools::date_iso2timestamp($datum_bis) - $tage * 24 * 3600)));
-        $neuere_url_std   = (str_replace("-", "", $datum_bis) < date("Ymd") ? $this->createUrl("index/baDokumente", array("ba_nr" => $ba_nr, "datum_max" => date("Y-m-d", RISTools::date_iso2timestamp($datum_bis) + $tage * 24 * 3600))) : null);
-        return array(
+        $aeltere_url_std  = $this->createUrl("index/baDokumente", ["ba_nr" => $ba_nr, "datum_max" => date("Y-m-d", RISTools::date_iso2timestamp($datum_bis) - $tage * 24 * 3600)]);
+        $neuere_url_std   = (str_replace("-", "", $datum_bis) < date("Ymd") ? $this->createUrl("index/baDokumente", ["ba_nr" => $ba_nr, "datum_max" => date("Y-m-d", RISTools::date_iso2timestamp($datum_bis) + $tage * 24 * 3600)]) : null);
+        return [
             "datum_von"        => $datum_von,
             "datum_bis"        => $datum_bis,
             "aeltere_url_std"  => $aeltere_url_std,
@@ -559,7 +559,7 @@ class IndexController extends RISBaseController
             "antraege"         => $antraege,
             "geodata"          => $geodata,
             "geodata_overflow" => $geodata_overflow,
-        );
+        ];
     }
 
     /**
@@ -571,18 +571,18 @@ class IndexController extends RISBaseController
         $data = $this->ba_dokumente_nach_datum($ba_nr, $datum_max);
 
         ob_start();
-        $this->renderPartial('index_antraege_liste', array_merge(array(
+        $this->renderPartial('index_antraege_liste', array_merge([
             "weiter_links_oben" => true,
-        ), $data));
+        ], $data));
 
         Header("Content-Type: application/json; charset=UTF-8");
-        echo json_encode(array(
+        echo json_encode([
             "datum_von"        => $data["datum_von"],
             "datum_bis"        => $data["datum_bis"],
             "html"             => ob_get_clean(),
             "geodata"          => $data["geodata"],
             "geodata_overflow" => $data["geodata_overflow"],
-        ));
+        ]);
         Yii::app()->end();
     }
 
@@ -603,13 +603,13 @@ class IndexController extends RISBaseController
 
         $antraege_data = $this->ba_dokumente_nach_datum($ba_nr, $datum_max);
 
-        $termine          = Termin::model()->termine_stadtrat_zeitraum($ba_nr, date("Y-m-d 00:00:00", time() - $tage_vergangenheit * 24 * 3600), date("Y-m-d 00:00:00", time() + $tage_zukunft * 24 * 3600), true)->findAll(array('order' => 'termin DESC'));
+        $termine          = Termin::model()->termine_stadtrat_zeitraum($ba_nr, date("Y-m-d 00:00:00", time() - $tage_vergangenheit * 24 * 3600), date("Y-m-d 00:00:00", time() + $tage_zukunft * 24 * 3600), true)->findAll(['order' => 'termin DESC']);
         $termin_dokumente = Termin::model()->neueste_ba_dokumente($ba_nr, date("Y-m-d 00:00:00", time() - $tage_vergangenheit * 24 * 3600), date("Y-m-d H:i:s", time()), false)->findAll();
         $termine          = Termin::groupAppointments($termine);
 
         /** @var Termin[] $bvs */
-        $bvs     = Termin::model()->findAllByAttributes(array("ba_nr" => $ba_nr, "typ" => Termin::$TYP_BV), array("order" => "termin DESC"));
-        $bvs_arr = array();
+        $bvs     = Termin::model()->findAllByAttributes(["ba_nr" => $ba_nr, "typ" => Termin::$TYP_BV], ["order" => "termin DESC"]);
+        $bvs_arr = [];
         foreach ($bvs as $bv) $bvs_arr[] = $bv->toArr();
 
 
@@ -617,7 +617,7 @@ class IndexController extends RISBaseController
         $ba      = Bezirksausschuss::model()->findByPk($ba_nr);
         $gremien = $ba->gremien;
 
-        $this->render("ba_startseite", array_merge(array(
+        $this->render("ba_startseite", array_merge([
             "ba"                           => $ba,
             "gremien"                      => $gremien,
             "termine"                      => $termine,
@@ -628,7 +628,7 @@ class IndexController extends RISBaseController
             "tage_vergangenheit_dokumente" => static::$BA_DOKUMENTE_TAGE_PRO_SEITE,
             "fraktionen"                   => StadtraetIn::getGroupedByFraktion(date("Y-m-d"), $ba_nr),
             "explizites_datum"             => ($datum_max != ""),
-        ), $antraege_data));
+        ], $antraege_data));
     }
 
     /**
@@ -642,11 +642,11 @@ class IndexController extends RISBaseController
         $ba      = Bezirksausschuss::model()->findByPk($ba_nr);
 
         $antraege_data = $this->ba_dokumente_nach_datum($ba_nr, $datum_max, static::$BA_DOKUMENTE_TAGE_PRO_SEITE * 2);
-        $this->render("ba_dokumente", array_merge(array(
+        $this->render("ba_dokumente", array_merge([
             "ba"                           => $ba,
             "tage_vergangenheit_dokumente" => static::$BA_DOKUMENTE_TAGE_PRO_SEITE * 2,
             "explizites_datum"             => ($datum_max != ""),
-        ), $antraege_data));
+        ], $antraege_data));
     }
 
     /**
@@ -659,32 +659,32 @@ class IndexController extends RISBaseController
         if ($heute) $i = 1;
         else        $i = 0;
 
-        $rus = array();
+        $rus = [];
 
         do {
             if ($heute) {
                 $datum_von = date("Y-m-d", $date_ts - 3600 * 24 * $i) . " 00:00:00";
                 $datum_bis = date("Y-m-d H:i:s");
                 if ($i == 1) {
-                    $ru = Rathausumschau::model()->findByAttributes(array("datum" => date("Y-m-d")));
+                    $ru = Rathausumschau::model()->findByAttributes(["datum" => date("Y-m-d")]);
                     if ($ru) $rus[] = $ru;
                 }
             } else {
                 $datum_von = date("Y-m-d", $date_ts - 3600 * 24 * $i) . " 00:00:00";
                 $datum_bis = date("Y-m-d", $date_ts - 3600 * 24 * $i) . " 23:59:59";
             }
-            $ru = Rathausumschau::model()->findByAttributes(array("datum" => date("Y-m-d", $date_ts - 3600 * 24 * $i)));
+            $ru = Rathausumschau::model()->findByAttributes(["datum" => date("Y-m-d", $date_ts - 3600 * 24 * $i)]);
             if ($ru) $rus[] = $ru;
             /** @var array|Antrag[] $antraege */
             $antraege          = Antrag::model()->neueste_stadtratsantragsdokumente(null, $datum_von, $datum_bis)->findAll();
-            $antraege_stadtrat = $antraege_sonstige = array();
+            $antraege_stadtrat = $antraege_sonstige = [];
             foreach ($antraege as $ant) {
                 if ($ant->ba_nr === null) $antraege_stadtrat[] = $ant;
                 else $antraege_sonstige[] = $ant;
             }
             $i++;
         } while (count($antraege) == 0 && $i < 10);
-        return array($antraege, $antraege_stadtrat, $antraege_sonstige, $rus, $datum_von, $datum_bis);
+        return [$antraege, $antraege_stadtrat, $antraege_sonstige, $rus, $datum_von, $datum_bis];
     }
 
 
@@ -700,24 +700,24 @@ class IndexController extends RISBaseController
         $gestern = date("Y-m-d", RISTools::date_iso2timestamp($datum_von . " 00:00:00") - 1);
 
         ob_start();
-        $this->renderPartial('index_antraege_liste', array(
-            "aeltere_url_ajax"  => $this->createUrl("index/stadtratAntraegeAjaxDatum", array("datum_max" => $gestern)),
-            "aeltere_url_std"   => $this->createUrl("index/startseite", array("datum_max" => $gestern)) . "#stadtratsdokumente_holder",
+        $this->renderPartial('index_antraege_liste', [
+            "aeltere_url_ajax"  => $this->createUrl("index/stadtratAntraegeAjaxDatum", ["datum_max" => $gestern]),
+            "aeltere_url_std"   => $this->createUrl("index/startseite", ["datum_max" => $gestern]) . "#stadtratsdokumente_holder",
             "neuere_url_ajax"   => null,
             "neuere_url_std"    => null,
             "antraege"          => $antraege,
             "datum"             => $datum_von,
             "weiter_links_oben" => true,
             "rathausumschauen"  => $rus,
-        ));
+        ]);
 
         Header("Content-Type: application/json; charset=UTF-8");
-        echo json_encode(array(
+        echo json_encode([
             "datum"            => $datum_von,
             "html"             => ob_get_clean(),
             "geodata"          => $geodata,
             "geodata_overflow" => $geodata_overflow
-        ));
+        ]);
         Yii::app()->end();
     }
 
@@ -744,9 +744,9 @@ class IndexController extends RISBaseController
         list($geodata, $geodata_overflow) = $this->antraege2geodata($antraege);
         $gestern = date("Y-m-d", RISTools::date_iso2timestamp($datum_von) - 1);
 
-        $this->render('startseite', array(
-            "aeltere_url_ajax"  => $this->createUrl("index/stadtratAntraegeAjaxDatum", array("datum_max" => $gestern)),
-            "aeltere_url_std"   => $this->createUrl("index/startseite", array("datum_max" => $gestern)) . "#stadtratsdokumente_holder",
+        $this->render('startseite', [
+            "aeltere_url_ajax"  => $this->createUrl("index/stadtratAntraegeAjaxDatum", ["datum_max" => $gestern]),
+            "aeltere_url_std"   => $this->createUrl("index/startseite", ["datum_max" => $gestern]) . "#stadtratsdokumente_holder",
             "neuere_url_ajax"   => null,
             "neuere_url_std"    => null,
             "antraege_sonstige" => $antraege_sonstige,
@@ -757,18 +757,18 @@ class IndexController extends RISBaseController
             "explizites_datum"  => ($datum_max != ""),
             "statistiken"       => RISMetadaten::getStats(),
             "rathausumschauen"  => $rus,
-        ));
+        ]);
     }
 
     public function actionPersonen($ba = null)
     {
         $this->top_menu = "personen";
 
-        $this->render('personen', array(
+        $this->render('personen', [
             "stadtraetInnen" => StadtraetIn::getByFraktion(date("Y-m-d"), $ba),
             "personen_typ"   => ($ba > 0 ? "ba" : "str"),
             "ba_nr"          => $ba
-        ));
+        ]);
     }
 
     /**
@@ -779,16 +779,16 @@ class IndexController extends RISBaseController
         /** @var StadtraetIn $stadtraetIn */
         $stadtraetIn = StadtraetIn::model()->findByPk($id);
 
-        $this->render("stadtraetIn", array(
+        $this->render("stadtraetIn", [
             "stadtraetIn" => $stadtraetIn,
-        ));
+        ]);
     }
 
 
     public function actionHighlights()
     {
-        $dokumente = Dokument::model()->with("antrag")->findAll(array("condition" => "highlight IS NOT NULL", "order" => "highlight DESC"));
-        $this->render("dokumentenliste", array("dokumente" => $dokumente));
+        $dokumente = Dokument::model()->with("antrag")->findAll(["condition" => "highlight IS NOT NULL", "order" => "highlight DESC"]);
+        $this->render("dokumentenliste", ["dokumente" => $dokumente]);
     }
 
 
@@ -799,9 +799,9 @@ class IndexController extends RISBaseController
         /** @var StadtraetIn[] $stadtraetInnen */
         $stadtraetInnen = StadtraetIn::model()->findAll();
 
-        $this->render('quicksearch_prefetch', array(
+        $this->render('quicksearch_prefetch', [
             'stadtraetInnen' => $stadtraetInnen,
-        ));
+        ]);
     }
 
 
@@ -816,7 +816,7 @@ class IndexController extends RISBaseController
             else
                 $this->render('error', $error);
         } else {
-            $this->render('error', array("code" => 400, "message" => "Ein Fehler ist aufgetreten"));
+            $this->render('error', ["code" => 400, "message" => "Ein Fehler ist aufgetreten"]);
         }
     }
 
@@ -827,12 +827,12 @@ class IndexController extends RISBaseController
         /** @var Dokument $dokument */
         $dokument = Dokument::getCachedByID($id);
         if (!$dokument) {
-            $this->render('error', array("code" => 404, "message" => "Das Dokument wurde leider nicht gefunden."));
+            $this->render('error', ["code" => 404, "message" => "Das Dokument wurde leider nicht gefunden."]);
         } else {
-            $this->render('dokumentenanzeige', array(
+            $this->render('dokumentenanzeige', [
                 "id"       => $id,
                 "dokument" => $dokument
-            ));
+            ]);
         }
     }
 
@@ -843,20 +843,20 @@ class IndexController extends RISBaseController
     public function actionShariffData($url)
     {
         Header("Content-Type: application/json; charset=UTF-8");
-        $shariff = new \Heise\Shariff\Backend(array(
+        $shariff = new \Heise\Shariff\Backend([
             "domain"   => $_SERVER["HTTP_HOST"],
-            "services" => array("Facebook", "Twitter", "GooglePlus"),
-            "cache"    => array(
+            "services" => ["Facebook", "Twitter", "GooglePlus"],
+            "cache"    => [
                 "ttl"      => 60,
                 "cacheDir" => TMP_PATH,
-            )
-        ));
+            ]
+        ]);
         echo json_encode($shariff->get($url));
         Yii::app()->end();
     }
 
     public function actionBaListe()
     {
-        $this->render('ba_liste', array("bas" => Bezirksausschuss::model()->findAll()));
+        $this->render('ba_liste', ["bas" => Bezirksausschuss::model()->findAll()]);
     }
 }

--- a/protected/controllers/InfosController.php
+++ b/protected/controllers/InfosController.php
@@ -16,10 +16,10 @@ class InfosController extends RISBaseController
             $this->msg_ok = "Gespeichert.";
         }
 
-        $this->render("stadtpolitik", array(
+        $this->render("stadtpolitik", [
             "text"   => $text,
             "my_url" => $this->createUrl("infos/soFunktioniertStadtpolitik"),
-        ));
+        ]);
     }
 
     public function actionImpressum()
@@ -63,10 +63,10 @@ class InfosController extends RISBaseController
         /** @var Rechtsdokument $dok */
         $dok = Rechtsdokument::model()->findByPk($id);
         if (!$dok) {
-            $this->render('../index/error', array("code" => 404, "message" => "Das Dokument wurde nicht gefunden"));
+            $this->render('../index/error', ["code" => 404, "message" => "Das Dokument wurde nicht gefunden"]);
             Yii::app()->end();
         }
-        $this->render("stadtrecht_dokument", array("dokument" => $dok));
+        $this->render("stadtrecht_dokument", ["dokument" => $dok]);
     }
 
     /**
@@ -87,12 +87,12 @@ class InfosController extends RISBaseController
             $this->msg_ok = "Gespeichert.";
         }
 
-        $this->render("std", array(
+        $this->render("std", [
             "text"            => $text,
             "my_url"          => $my_url,
             "show_title"      => $show_title,
             "insert_tooltips" => $insert_tooltips,
-        ));
+        ]);
     }
 
 
@@ -112,11 +112,11 @@ class InfosController extends RISBaseController
 
             RISTools::send_email(Yii::app()->params['adminEmail'], "[München Transparent] Feedback", $text, null, "feedback");
 
-            $this->render('feedback_done', array());
+            $this->render('feedback_done', []);
         } else {
-            $this->render('feedback_form', array(
+            $this->render('feedback_form', [
                 "current_url" => Yii::app()->createUrl("infos/feedback"),
-            ));
+            ]);
         }
     }
 
@@ -135,13 +135,13 @@ class InfosController extends RISBaseController
             $text->save();
         }
 
-        $eintraege = Text::model()->findAllByAttributes(array(
+        $eintraege = Text::model()->findAllByAttributes([
             "typ" => Text::$TYP_GLOSSAR,
-        ), array("order" => "titel"));
+        ], ["order" => "titel"]);
 
-        $this->render('glossar', array(
+        $this->render('glossar', [
             "eintraege" => $eintraege,
-        ));
+        ]);
     }
 
 
@@ -156,10 +156,10 @@ class InfosController extends RISBaseController
         $this->top_menu = "so_funktioniert";
 
         /** @var Text $eintrag */
-        $eintrag = Text::model()->findByAttributes(array(
+        $eintrag = Text::model()->findByAttributes([
             "id"  => $id,
             "typ" => Text::$TYP_GLOSSAR,
-        ));
+        ]);
         if (!$eintrag) throw new Exception("Nicht gefunden");
 
         if (AntiXSS::isTokenSet("speichern")) {
@@ -177,8 +177,8 @@ class InfosController extends RISBaseController
             $this->redirect($this->createUrl("infos/glossar"));
         }
 
-        $this->render('glossar_bearbeiten', array(
+        $this->render('glossar_bearbeiten', [
             "eintrag" => $eintrag,
-        ));
+        ]);
     }
 }

--- a/protected/controllers/PersonenController.php
+++ b/protected/controllers/PersonenController.php
@@ -10,11 +10,11 @@ class PersonenController extends RISBaseController
     {
         $this->top_menu = "personen";
 
-        $this->render('index', array(
+        $this->render('index', [
             "personen"     => StadtraetIn::getByFraktion(date("Y-m-d"), $ba),
             "personen_typ" => ($ba > 0 ? "ba" : "str"),
             "ba_nr"        => $ba
-        ));
+        ]);
     }
 
     /**
@@ -27,9 +27,9 @@ class PersonenController extends RISBaseController
         /** @var StadtraetIn $person */
         $person = StadtraetIn::model()->findByPk($id);
 
-        $this->render("person", array(
+        $this->render("person", [
             "person" => $person,
-        ));
+        ]);
     }
 
     /**
@@ -76,9 +76,9 @@ class PersonenController extends RISBaseController
             $this->msg_ok = "Gespeichert";
         }
 
-        $this->render("person-bearbeiten", array(
+        $this->render("person-bearbeiten", [
             "person" => $person,
-        ));
+        ]);
     }
 
 
@@ -89,15 +89,15 @@ class PersonenController extends RISBaseController
     {
         $this->top_menu = "personen";
 
-        $this->requireLogin($this->createUrl("personen/binIch", array("id" => $id)));
+        $this->requireLogin($this->createUrl("personen/binIch", ["id" => $id]));
 
         /** @var StadtraetIn $person */
         $person = StadtraetIn::model()->findByPk($id);
         if ($person->benutzerIn_id !== null) $this->errorMessageAndDie(403, "Diese Person ist schon einem Account zugeordnet. Falls das ein Fehler ist, schreiben Sie uns bitte per Mail (" . Yii::app()->params["adminEmail"] . ")");
 
-        $this->render("person-binich", array(
+        $this->render("person-binich", [
             "person" => $person,
-        ));
+        ]);
     }
 
 

--- a/protected/controllers/TermineController.php
+++ b/protected/controllers/TermineController.php
@@ -10,25 +10,25 @@ class TermineController extends RISBaseController
     private function getFullcalendarStruct($appointments)
     {
         $appointments_data = Termin::groupAppointments($appointments);
-        $jsdata            = array();
+        $jsdata            = [];
         $has_weekend       = false;
         foreach ($appointments_data as $appointment) {
-            $d        = array(
+            $d        = [
                 "title"    => str_replace("Ausschuss für ", "", implode(", ", array_keys($appointment["gremien"]))),
                 "start"    => str_replace(" ", "T", $appointment["datum_iso"]),
                 "url"      => $appointment["link"],
                 "abgesagt" => $appointment["abgesagt"],
-            );
+            ];
             $jsdata[] = $d;
             $weekday  = date("N", $appointment["datum_ts"]);
             if ($weekday == 6 || $weekday == 7) {
                 $has_weekend = true;
             }
         }
-        return array(
+        return [
             "has_weekend" => $has_weekend,
             "data"        => $jsdata,
-        );
+        ];
     }
 
 
@@ -90,14 +90,14 @@ class TermineController extends RISBaseController
 
         $fullcalendar_struct = $this->getFullCalendarStructByMonth(date("Y"), date("m"));
 
-        $this->render("index", array(
+        $this->render("index", [
             "termine_zukunft"       => $gruppiert_zukunft,
             "termine_vergangenheit" => $gruppiert_vergangenheit,
             "termin_dokumente"      => $termin_dokumente,
             "fullcalendar_struct"   => $fullcalendar_struct,
             "tage_vergangenheit"    => $tage_vergangenheit,
             "tage_zukunft"          => $tage_zukunft,
-        ));
+        ]);
     }
 
     /**
@@ -112,7 +112,7 @@ class TermineController extends RISBaseController
         /** @var Termin $termin */
         $termin = Termin::model()->findByPk($termin_id);
         if (!$termin) {
-            $this->render('/index/error', array("code" => 404, "message" => "Der Termin wurde nicht gefunden"));
+            $this->render('/index/error', ["code" => 404, "message" => "Der Termin wurde nicht gefunden"]);
             return;
         }
 
@@ -132,11 +132,11 @@ class TermineController extends RISBaseController
             }
         }
 
-        $this->render("anzeige", array(
+        $this->render("anzeige", [
             "termin" => $termin,
             "to_pdf" => $to_pdf,
             "to_db"  => $to_db,
-        ));
+        ]);
     }
 
 
@@ -150,13 +150,13 @@ class TermineController extends RISBaseController
         /** @var Termin $termin */
         $termin = Termin::model()->findByPk($termin_id);
         if (!$termin) {
-            $this->render('/index/error', array("code" => 404, "message" => "Der Termin wurde nicht gefunden"));
+            $this->render('/index/error', ["code" => 404, "message" => "Der Termin wurde nicht gefunden"]);
             return;
         }
 
-        $this->renderPartial("ics_all", array(
+        $this->renderPartial("ics_all", [
             "alle_termine" => $termin->alleTermineDerReihe(),
-        ));
+        ]);
     }
 
     /**
@@ -169,13 +169,13 @@ class TermineController extends RISBaseController
         /** @var Termin $termin */
         $termin = Termin::model()->findByPk($termin_id);
         if (!$termin) {
-            $this->render('/index/error', array("code" => 404, "message" => "Der Termin wurde nicht gefunden"));
+            $this->render('/index/error', ["code" => 404, "message" => "Der Termin wurde nicht gefunden"]);
             return;
         }
 
-        $this->renderPartial("ics_single", array(
+        $this->renderPartial("ics_single", [
             "termin" => $termin,
-        ));
+        ]);
     }
 
     /**
@@ -183,7 +183,7 @@ class TermineController extends RISBaseController
      */
     public function actionTopGeoExport($termin_id)
     {
-        $this->render('/index/error', array("code" => 404, "message" => "Diese Seite gibt es (noch) nicht."));
+        $this->render('/index/error', ["code" => 404, "message" => "Diese Seite gibt es (noch) nicht."]);
         return;
 
         $termin_id = IntVal($termin_id);
@@ -194,9 +194,9 @@ class TermineController extends RISBaseController
         /** @var Termin $sitzung */
         $termin = Termin::model()->findByPk($termin_id);
 
-        $this->renderPartial("top_geo_export", array(
+        $this->renderPartial("top_geo_export", [
             "termin" => $termin
-        ));
+        ]);
     }
 
 
@@ -207,9 +207,9 @@ class TermineController extends RISBaseController
         $sql = Yii::app()->db->createCommand();
         $sql->select('a.*, b.name')->from('termine a')->join('gremien b', 'a.gremium_id = b.id')->where('b.ba_nr > 0')->andWhere('b.name LIKE "%Voll%"')->andWhere("a.termin >= CURRENT_DATE()")->order("termin");
         $termine = $sql->queryAll();
-        $this->render("ba_zukunft_html", array(
+        $this->render("ba_zukunft_html", [
             "termine" => $termine
-        ));
+        ]);
     }
     /**
      */
@@ -218,9 +218,9 @@ class TermineController extends RISBaseController
         $sql = Yii::app()->db->createCommand();
         $sql->select('a.*, b.name')->from('termine a')->join('gremien b', 'a.gremium_id = b.id')->where('b.ba_nr > 0')->andWhere('b.name LIKE "%Voll%"')->andWhere("a.termin >= CURRENT_DATE()")->order("termin");
         $termine = $sql->queryAll();
-        $this->renderPartial("ba_zukunft_csv", array(
+        $this->renderPartial("ba_zukunft_csv", [
             "termine" => $termine
-        ));
+        ]);
     }
 
     /**
@@ -231,13 +231,13 @@ class TermineController extends RISBaseController
         /** @var Termin $sitzung */
         $termin = Termin::model()->findByPk($termin_id);
         if (!$termin) {
-            $this->render('/index/error', array("code" => 404, "message" => "Der Termin wurde nicht gefunden"));
+            $this->render('/index/error', ["code" => 404, "message" => "Der Termin wurde nicht gefunden"]);
             return;
         }
 
-        $this->render("abo_info", array(
+        $this->render("abo_info", [
             "termin" => $termin,
-        ));
+        ]);
     }
 
 
@@ -251,13 +251,13 @@ class TermineController extends RISBaseController
         $principalBackend = new TermineCalDAVPrincipalBackend($termin_id);
         $calendarBackend  = new TermineCalDAVCalendarBackend($termin_id);
 
-        $tree = array(
+        $tree = [
             new Sabre\CalDAV\Principal\Collection($principalBackend),
             new Sabre\CalDAV\CalendarRoot($principalBackend, $calendarBackend),
-        );
+        ];
 
         $server = new TermineCalDAVServerBugfix($tree);
-        $server->setBaseUri(Yii::app()->createUrl("termine/dav", array("termin_id" => $termin_id)));
+        $server->setBaseUri(Yii::app()->createUrl("termine/dav", ["termin_id" => $termin_id]));
 
         $authBackend = new TermineCalDAVAuthBackend();
         $authPlugin  = new \Sabre\DAV\Auth\Plugin($authBackend, 'SabreDAV');
@@ -284,8 +284,8 @@ class TermineController extends RISBaseController
     public function actionBaTermineAlle($ba_nr)
     {
         /** @var Termin[] $termine */
-        $termine    = Termin::model()->findAllByAttributes(array("ba_nr" => $ba_nr), array("order" => "termin DESC"));
-        $termin_arr = array();
+        $termine    = Termin::model()->findAllByAttributes(["ba_nr" => $ba_nr], ["order" => "termin DESC"]);
+        $termin_arr = [];
         foreach ($termine as $t) {
             $termin_arr[] = $t->toArr();
         }
@@ -293,10 +293,10 @@ class TermineController extends RISBaseController
         /** @var Bezirksausschuss $ba */
         $ba = Bezirksausschuss::model()->findByPk($ba_nr);
 
-        $this->render("ba_termine_alle", array(
+        $this->render("ba_termine_alle", [
             "ba"      => $ba,
             "termine" => $termin_arr,
-        ));
+        ]);
     }
 
 

--- a/protected/controllers/ThemenController.php
+++ b/protected/controllers/ThemenController.php
@@ -6,7 +6,7 @@ class ThemenController extends RISBaseController
     public function actionReferat($referat_url)
     {
         /** @var Referat $ref */
-        $ref = Referat::model()->findByAttributes(array("urlpart" => $referat_url));
+        $ref = Referat::model()->findByAttributes(["urlpart" => $referat_url]);
         if (!$ref) die("Nicht gefunden");
 
         $this->top_menu = "themen";
@@ -15,7 +15,7 @@ class ThemenController extends RISBaseController
         $bis              = date("Y-m-d H:i:s", time());
         $antraege_referat = Antrag::model()->neueste_stadtratsantragsdokumente_referat($ref->id, $von, $bis)->findAll();
 
-        $text = Text::model()->findByAttributes(array("typ" => 2, "titel" => $ref->name));
+        $text = Text::model()->findByAttributes(["typ" => 2, "titel" => $ref->name]);
         $my_url = Yii::app()->createUrl("/themen/referat/" . $referat_url);
 
         if ($this->binContentAdmin() && AntiXSS::isTokenSet("save")) {
@@ -25,12 +25,12 @@ class ThemenController extends RISBaseController
             $this->msg_ok = "Gespeichert.";
         }
 
-        $this->render("referat", array(
+        $this->render("referat", [
             "referat"          => $ref,
             "antraege_referat" => $antraege_referat,
             "text"             => $text,
             "my_url"           => $my_url,
-        ));
+        ]);
     }
 
     /**
@@ -39,11 +39,11 @@ class ThemenController extends RISBaseController
     public function actionIndex()
     {
         $this->top_menu = "themen";
-        $this->render("index", array(
+        $this->render("index", [
             "referate"   => Referat::model()->findAll(),
             "highlights" => Dokument::getHighlightDokumente(5),
             "tags"       => Tag::getTopTags(10),
-        ));
+        ]);
     }
 
     /**
@@ -61,10 +61,10 @@ class ThemenController extends RISBaseController
 
         $antraege_tag = $tag->antraege;
 
-        $this->render("tag", array(
+        $this->render("tag", [
             "tag"          => $tag,
             "antraege_tag" => $antraege_tag,
-        ));
+        ]);
     }
 
 

--- a/protected/models/Antrag.php
+++ b/protected/models/Antrag.php
@@ -50,14 +50,14 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public static $TYP_BA_INITIATIVE = "ba_initiative";
     public static $TYP_BV_EMPFEHLUNG = "bv_empfehlung";
 
-    public static $TYPEN_ALLE = array(
+    public static $TYPEN_ALLE = [
         "stadtrat_antrag"         => "Stadtratsantrag|Stadtratsanträge",
         "stadtrat_vorlage"        => "Stadtratsvorlage|Stadtratsvorlagen",
         "ba_antrag"               => "BA-Antrag|BA-Anträge",
         "ba_initiative"           => "BA-Initiative|BA-Initiativen",
         "stadtrat_vorlage_geheim" => "Geheime Stadtratsvorlage|Geheime Stadtratsvorlagen",
         "bv_empfehlung"           => "BV-Empfehlung|BV-Empfehlungen",
-    );
+    ];
 
     /**
      * Returns the static model of the specified AR class.
@@ -84,18 +84,18 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, typ, datum_letzte_aenderung, antrags_nr, wahlperiode, betreff, status', 'required'),
-            array('id, ba_nr, vorgang_id, referat_id', 'numerical', 'integerOnly' => true),
-            array('typ', 'length', 'max' => 16),
-            array('antrags_nr', 'length', 'max' => 20),
-            array('referat', 'length', 'max' => 500),
-            array('referent', 'length', 'max' => 200),
-            array('wahlperiode, antrag_typ, status', 'length', 'max' => 50),
-            array('bearbeitung', 'length', 'max' => 100),
-            array('typ, ba_nr, antrags_nr, bearbeitungsfrist, registriert_am, erledigt_am, referat, referent, wahlperiode, antrag_typ, betreff, kurzinfo, status, bearbeitung, fristverlaengerung, initiatorInnen, initiative_to_aufgenommen', 'safe'),
-            array('typ, datum_letzte_aenderung, ba_nr, gestellt_am, gestellt_von, antrags_nr, bearbeitungsfrist, registriert_am, erledigt_am, referat, referent, wahlperiode, antrag_typ, betreff, kurzinfo, status, bearbeitung, fristverlaengerung, initiatorInnen, initiative_to_aufgenommen', 'safe', 'on' => 'insert'),
-        );
+        return [
+            ['id, typ, datum_letzte_aenderung, antrags_nr, wahlperiode, betreff, status', 'required'],
+            ['id, ba_nr, vorgang_id, referat_id', 'numerical', 'integerOnly' => true],
+            ['typ', 'length', 'max' => 16],
+            ['antrags_nr', 'length', 'max' => 20],
+            ['referat', 'length', 'max' => 500],
+            ['referent', 'length', 'max' => 200],
+            ['wahlperiode, antrag_typ, status', 'length', 'max' => 50],
+            ['bearbeitung', 'length', 'max' => 100],
+            ['typ, ba_nr, antrags_nr, bearbeitungsfrist, registriert_am, erledigt_am, referat, referent, wahlperiode, antrag_typ, betreff, kurzinfo, status, bearbeitung, fristverlaengerung, initiatorInnen, initiative_to_aufgenommen', 'safe'],
+            ['typ, datum_letzte_aenderung, ba_nr, gestellt_am, gestellt_von, antrags_nr, bearbeitungsfrist, registriert_am, erledigt_am, referat, referent, wahlperiode, antrag_typ, betreff, kurzinfo, status, bearbeitung, fristverlaengerung, initiatorInnen, initiative_to_aufgenommen', 'safe', 'on' => 'insert'],
+        ];
     }
 
     /**
@@ -105,21 +105,21 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'ba'               => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-            'dokumente'        => array(self::HAS_MANY, 'Dokument', 'antrag_id'),
-            'ergebnisse'       => array(self::HAS_MANY, 'Tagesordnungspunkt', 'antrag_id'),
+        return [
+            'ba'               => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+            'dokumente'        => [self::HAS_MANY, 'Dokument', 'antrag_id'],
+            'ergebnisse'       => [self::HAS_MANY, 'Tagesordnungspunkt', 'antrag_id'],
             //'antraege_links_in' => array(self::HAS_MANY, 'Antrag', 'antrag1'),
             //'antraege_links_out' => array(self::HAS_MANY, 'AntraegeLinks', 'antrag2'),
-            'orte'             => array(self::HAS_MANY, 'AntragOrt', 'antrag_id'),
-            'antraegePersonen' => array(self::HAS_MANY, 'AntragPerson', 'antrag_id'),
-            'stadtraetInnen'   => array(self::MANY_MANY, 'StadtraetIn', 'antraege_stadtraetInnen(antrag_id, stadtraetIn_id)'),
-            'vorlage2antraege' => array(self::MANY_MANY, 'Antrag', 'antraege_vorlagen(antrag1, antrag2)'),
-            'antrag2vorlagen'  => array(self::MANY_MANY, 'Antrag', 'antraege_vorlagen(antrag2, antrag1)'),
-            'abos'             => array(self::MANY_MANY, 'AntragAbo', 'antraege_abos(antrag_id, benutzerIn_id)'),
-            'vorgang'          => array(self::BELONGS_TO, 'Vorgang', 'vorgang_id'),
-            'tags'             => array(self::MANY_MANY, 'Tag', 'antraege_tags(antrag_id, tag_id)'),
-        );
+            'orte'             => [self::HAS_MANY, 'AntragOrt', 'antrag_id'],
+            'antraegePersonen' => [self::HAS_MANY, 'AntragPerson', 'antrag_id'],
+            'stadtraetInnen'   => [self::MANY_MANY, 'StadtraetIn', 'antraege_stadtraetInnen(antrag_id, stadtraetIn_id)'],
+            'vorlage2antraege' => [self::MANY_MANY, 'Antrag', 'antraege_vorlagen(antrag1, antrag2)'],
+            'antrag2vorlagen'  => [self::MANY_MANY, 'Antrag', 'antraege_vorlagen(antrag2, antrag1)'],
+            'abos'             => [self::MANY_MANY, 'AntragAbo', 'antraege_abos(antrag_id, benutzerIn_id)'],
+            'vorgang'          => [self::BELONGS_TO, 'Vorgang', 'vorgang_id'],
+            'tags'             => [self::MANY_MANY, 'Tag', 'antraege_tags(antrag_id, tag_id)'],
+        ];
     }
 
 
@@ -129,9 +129,9 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function addVorlage($vorlage)
     {
         try {
-            Yii::app()->db->createCommand()->insert("antraege_vorlagen", array("antrag1" => $vorlage->id, "antrag2" => $this->id));
-            $this->antrag2vorlagen     = array_merge($this->antrag2vorlagen, array($vorlage));
-            $vorlage->vorlage2antraege = array_merge($vorlage->vorlage2antraege, array($this));
+            Yii::app()->db->createCommand()->insert("antraege_vorlagen", ["antrag1" => $vorlage->id, "antrag2" => $this->id]);
+            $this->antrag2vorlagen     = array_merge($this->antrag2vorlagen, [$vorlage]);
+            $vorlage->vorlage2antraege = array_merge($vorlage->vorlage2antraege, [$this]);
         } catch (Exception $e) {
         }
     }
@@ -142,9 +142,9 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function addAntrag($antrag)
     {
         try {
-            Yii::app()->db->createCommand()->insert("antraege_vorlagen", array("antrag2" => $antrag->id, "antrag1" => $this->id));
-            $this->vorlage2antraege  = array_merge($this->vorlage2antraege, array($antrag));
-            $antrag->antrag2vorlagen = array_merge($antrag->antrag2vorlagen, array($this));
+            Yii::app()->db->createCommand()->insert("antraege_vorlagen", ["antrag2" => $antrag->id, "antrag1" => $this->id]);
+            $this->vorlage2antraege  = array_merge($this->vorlage2antraege, [$antrag]);
+            $antrag->antrag2vorlagen = array_merge($antrag->antrag2vorlagen, [$this]);
         } catch (Exception $e) {
         }
     }
@@ -154,7 +154,7 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                        => 'ID',
             'vorgang_id'                => 'Vorgangs-ID',
             'typ'                       => 'Typ',
@@ -178,7 +178,7 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
             'fristverlaengerung'        => 'Fristverlaengerung',
             'initiatorInnen'            => 'InitiatorInnen',
             'initiative_to_aufgenommen' => 'Initiative To Aufgenommen',
-        );
+        ];
     }
 
     /**
@@ -191,14 +191,14 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function neueste_stadtratsantragsdokumente($ba_nr, $zeit_von, $zeit_bis, $limit = 0)
     {
         $ba_sql = ($ba_nr > 0 ? " = " . IntVal($ba_nr) : " IS NULL");
-        $params = array(
+        $params = [
             'condition' => 'ba_nr ' . $ba_sql . ' AND datum_letzte_aenderung >= "' . addslashes($zeit_von) . '"',
             'order'     => 'datum DESC',
-            'with'      => array(
-                'dokumente' => array(
+            'with'      => [
+                'dokumente' => [
                     'condition' => 'datum >= "' . addslashes($zeit_von) . '" AND datum <= "' . addslashes($zeit_bis) . '"',
-                ),
-            ));
+                ],
+            ]];
         if ($limit > 0) $params['limit'] = $limit;
         $this->getDbCriteria()->mergeWith($params);
         return $this;
@@ -213,21 +213,21 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
      */
     public function neueste_stadtratsantragsdokumente_geo($ba_nr, $zeit_von, $zeit_bis, $limit = 0)
     {
-        $params = array(
+        $params = [
             'alias'     => 'a',
             'condition' => 'a.datum_letzte_aenderung >= "' . addslashes($zeit_von) . '"',
             'order'     => 'b.datum DESC',
-            'with'      => array(
-                'dokumente'          => array(
+            'with'      => [
+                'dokumente'          => [
                     'alias'     => 'b',
                     'condition' => 'b.datum >= "' . addslashes($zeit_von) . '" AND b.datum <= "' . addslashes($zeit_bis) . '"',
-                ),
-                'dokumente.orte'     => array(),
-                'dokumente.orte.ort' => array(
+                ],
+                'dokumente.orte'     => [],
+                'dokumente.orte.ort' => [
                     'alias'     => 'c',
                     'condition' => 'c.ba_nr = ' . IntVal($ba_nr) . ' AND c.to_hide = 0'
-                )
-            ));
+                ]
+            ]];
         if ($limit > 0) $params['limit'] = $limit;
         $this->getDbCriteria()->mergeWith($params);
         return $this;
@@ -242,16 +242,16 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
      */
     public function neueste_stadtratsantragsdokumente_referat($referat_id, $zeit_von, $zeit_bis, $limit = 0)
     {
-        $params = array(
+        $params = [
             'alias'     => 'a',
             'condition' => 'a.datum_letzte_aenderung >= "' . addslashes($zeit_von) . '" AND a.referat_id = ' . IntVal($referat_id),
             'order'     => 'b.datum DESC',
-            'with'      => array(
-                'dokumente' => array(
+            'with'      => [
+                'dokumente' => [
                     'alias'     => 'b',
                     'condition' => 'b.datum >= "' . addslashes($zeit_von) . '" AND b.datum <= "' . addslashes($zeit_bis) . '"',
-                ),
-            ));
+                ],
+            ]];
         if ($limit > 0) $params['limit'] = $limit;
         $this->getDbCriteria()->mergeWith($params);
         return $this;
@@ -295,7 +295,7 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
      */
     public function getHistoryDiffs()
     {
-        $histories = array();
+        $histories = [];
 
         $neu = new AntragHistory();
         $neu->setAttributes($this->getAttributes());
@@ -307,9 +307,9 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
          * $criteria->addBetweenCondition('user_date_created', $date['date_start'], $date['date_end']);
          * $rows = user::model()->findAllByAttributes($u
          */
-        $criteria = new CDbCriteria(array('order' => "datum_letzte_aenderung DESC"));
+        $criteria = new CDbCriteria(['order' => "datum_letzte_aenderung DESC"]);
         $criteria->addCondition("datum_letzte_aenderung >= '2014-05-01 00:00:00'");
-        $his = AntragHistory::model()->findAllByAttributes(array("id" => $this->id), $criteria);
+        $his = AntragHistory::model()->findAllByAttributes(["id" => $this->id], $criteria);
         foreach ($his as $alt) {
             $histories[] = new HistorienEintragAntrag($alt, $neu);
             $neu         = $alt;
@@ -325,10 +325,10 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function resetPersonen()
     {
         /** @var array|AntragPerson[] $alte */
-        $alte = AntragPerson::model()->findAllByAttributes(array("antrag_id" => $this->id));
+        $alte = AntragPerson::model()->findAllByAttributes(["antrag_id" => $this->id]);
         foreach ($alte as $alt) $alt->delete();
 
-        $indexed = array();
+        $indexed = [];
 
         $gestellt_von = RISTools::normalize_antragvon($this->gestellt_von);
         foreach ($gestellt_von as $x) if (!in_array($x["name_normalized"], $indexed)) {
@@ -363,9 +363,9 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
-        return Yii::app()->createUrl("antraege/anzeigen", array_merge(array("id" => $this->id), $add_params));
+        return Yii::app()->createUrl("antraege/anzeigen", array_merge(["id" => $this->id], $add_params));
     }
 
     /**
@@ -400,7 +400,7 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function getName($kurzfassung = false)
     {
         if ($kurzfassung) {
-            $betreff = str_replace(array("\n", "\r"), array(" ", " "), $this->betreff);
+            $betreff = str_replace(["\n", "\r"], [" ", " "], $this->betreff);
             $x       = explode(" Antrag Nr.", $betreff);
             $x       = explode(" Änderungsantrag ", $x[0]);
             $x       = explode("<strong>Antrag: </strong>", $x[0]);
@@ -448,9 +448,9 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function errateThemenverwandteDokumente($anz)
     {
         /** @var Dokument[] $dokumente */
-        $dokumente = array();
+        $dokumente = [];
         /** @var int[] $dokumente_count */
-        $dokumente_count = array();
+        $dokumente_count = [];
 
         foreach ($this->dokumente as $dokument) {
             $related = $dokument->solrMoreLikeThis(count($this->dokumente) + $anz);
@@ -466,7 +466,7 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
 
         arsort($dokumente_count);
 
-        $ret = array();
+        $ret = [];
         $i   = 0;
         foreach ($dokumente_count as $dok_id => $anz) if ($i++ < $anz) $ret[] = $dokumente[$dok_id];
         return $ret;
@@ -479,9 +479,9 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function errateThemenverwandteAntraege($limit)
     {
         /** @var Antrag[] $rel_antraege */
-        $rel_antraege = array();
+        $rel_antraege = [];
         /** @var int[] $rel_antraege_count */
-        $rel_antraege_count = array();
+        $rel_antraege_count = [];
 
         foreach ($this->dokumente as $dokument) if ($dokument->antrag_id > 0) {
             $related = $dokument->solrMoreLikeThis($limit * 2);
@@ -495,7 +495,7 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
             }
         }
 
-        $ret = array();
+        $ret = [];
         $i   = 0;
         foreach ($rel_antraege_count as $ant_id => $anz) {
             if (!ris_intern_antrag_ist_relevant_mlt($this, $rel_antraege[$ant_id])) continue;
@@ -550,11 +550,11 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
         //if ($this->vorgang_id > 0) return;
         $vorgang_id = 0;
         /** @var Antrag[] $gefundene_antraege */
-        $gefundene_antraege = array();
+        $gefundene_antraege = [];
         /** @var Tagesordnungspunkt[] $gefundene_ergebnisse */
-        $gefundene_ergebnisse = array();
+        $gefundene_ergebnisse = [];
         /** @var Dokument[] $gefundene_dokumente */
-        $gefundene_dokumente = array();
+        $gefundene_dokumente = [];
         try {
             static::rebuildVorgaengeCache_rek($this, $gefundene_antraege, $gefundene_ergebnisse, $gefundene_dokumente, $vorgang_id);
         } catch (Exception $e) {
@@ -614,7 +614,7 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
     public function findeAenderungen($von_ts, $bis_ts = 0)
     {
         /** @var RISAenderung[] $aenderungen */
-        $aenderungen = RISAenderung::model()->findAllByAttributes(array("typ" => $this->typ, "ris_id" => $this->id));
+        $aenderungen = RISAenderung::model()->findAllByAttributes(["typ" => $this->typ, "ris_id" => $this->id]);
         foreach ($aenderungen as $ae) {
             // @TODO var_dump($ae->getAttributes());
         }
@@ -622,20 +622,20 @@ class Antrag extends CActiveRecord implements IRISItemHasDocuments
 
     public function findeFraktionen()
     {
-        $parteien = array();
+        $parteien = [];
         foreach ($this->antraegePersonen as $person) {
             $name   = $person->person->getName(true);
             $partei = $person->person->ratePartei($this->gestellt_am);
             $key    = ($partei ? $partei : $name);
-            if (!isset($parteien[$key])) $parteien[$key] = array();
+            if (!isset($parteien[$key])) $parteien[$key] = [];
             $parteien[$key][] = $name;
         }
 
-        $ergebniss = array();
+        $ergebniss = [];
         foreach ($parteien as $partei => $personen) {
-            $personen_net = array();
+            $personen_net = [];
             foreach ($personen as $p) if ($p != $partei) $personen_net[] = $p;
-            $ergebniss[] = array("name" => $partei, "mitglieder" => $personen_net);
+            $ergebniss[] = ["name" => $partei, "mitglieder" => $personen_net];
         }
 
         return $ergebniss;

--- a/protected/models/AntragHistory.php
+++ b/protected/models/AntragHistory.php
@@ -58,18 +58,18 @@ class AntragHistory extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, typ, datum_letzte_aenderung', 'required'),
-            array('id, ba_nr, vorgang_id, referat_id', 'numerical', 'integerOnly' => true),
-            array('typ', 'length', 'max' => 16),
-            array('antrags_nr', 'length', 'max' => 20),
-            array('referat', 'length', 'max' => 500),
-            array('referent', 'length', 'max' => 200),
-            array('wahlperiode, antrag_typ, status', 'length', 'max' => 50),
-            array('bearbeitung', 'length', 'max' => 100),
-            array('gestellt_am, bearbeitungsfrist, registriert_am, erledigt_am, fristverlaengerung, initiative_to_aufgenommen', 'safe'),
-            array('id, typ, datum_letzte_aenderung, ba_nr, gestellt_am, gestellt_von, antrags_nr, bearbeitungsfrist, registriert_am, erledigt_am, referat, referent, wahlperiode, antrag_typ, betreff, kurzinfo, status, bearbeitung, fristverlaengerung, initiatorInnen, initiative_to_aufgenommen', 'safe', 'on' => 'insert'),
-        );
+        return [
+            ['id, typ, datum_letzte_aenderung', 'required'],
+            ['id, ba_nr, vorgang_id, referat_id', 'numerical', 'integerOnly' => true],
+            ['typ', 'length', 'max' => 16],
+            ['antrags_nr', 'length', 'max' => 20],
+            ['referat', 'length', 'max' => 500],
+            ['referent', 'length', 'max' => 200],
+            ['wahlperiode, antrag_typ, status', 'length', 'max' => 50],
+            ['bearbeitung', 'length', 'max' => 100],
+            ['gestellt_am, bearbeitungsfrist, registriert_am, erledigt_am, fristverlaengerung, initiative_to_aufgenommen', 'safe'],
+            ['id, typ, datum_letzte_aenderung, ba_nr, gestellt_am, gestellt_von, antrags_nr, bearbeitungsfrist, registriert_am, erledigt_am, referat, referent, wahlperiode, antrag_typ, betreff, kurzinfo, status, bearbeitung, fristverlaengerung, initiatorInnen, initiative_to_aufgenommen', 'safe', 'on' => 'insert'],
+        ];
     }
 
     /**
@@ -79,9 +79,9 @@ class AntragHistory extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'ba' => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-        );
+        return [
+            'ba' => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+        ];
     }
 
     /**
@@ -89,7 +89,7 @@ class AntragHistory extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                        => 'ID',
             'vorgang_id'                => 'Vorgangs-ID',
             'typ'                       => 'Typ',
@@ -113,6 +113,6 @@ class AntragHistory extends CActiveRecord
             'fristverlaengerung'        => 'Fristverlaengerung',
             'initiatorInnen'            => 'InitiatorInnen',
             'initiative_to_aufgenommen' => 'Initiative To Aufgenommen',
-        );
+        ];
     }
 }

--- a/protected/models/AntragOrt.php
+++ b/protected/models/AntragOrt.php
@@ -48,12 +48,12 @@ class AntragOrt extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('dokument_id, ort_name, ort_id, source, datum', 'required'),
-            array('antrag_id, termin_id, rathausumschau_id, dokument_id, ort_id', 'numerical', 'integerOnly' => true),
-            array('ort_name', 'length', 'max' => 100),
-            array('source', 'length', 'max' => 10),
-        );
+        return [
+            ['dokument_id, ort_name, ort_id, source, datum', 'required'],
+            ['antrag_id, termin_id, rathausumschau_id, dokument_id, ort_id', 'numerical', 'integerOnly' => true],
+            ['ort_name', 'length', 'max' => 100],
+            ['source', 'length', 'max' => 10],
+        ];
     }
 
     /**
@@ -63,13 +63,13 @@ class AntragOrt extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'dokument'       => array(self::BELONGS_TO, 'Dokument', 'dokument_id'),
-            'antrag'         => array(self::BELONGS_TO, 'Antrag', 'antrag_id'),
-            'termin'         => array(self::BELONGS_TO, 'Tagesordnungspunkt', 'termin_id'),
-            'rathausumschau' => array(self::BELONGS_TO, 'Rathausumschau', 'rathausumschau_id'),
-            'ort'            => array(self::BELONGS_TO, 'OrtGeo', 'ort_id'),
-        );
+        return [
+            'dokument'       => [self::BELONGS_TO, 'Dokument', 'dokument_id'],
+            'antrag'         => [self::BELONGS_TO, 'Antrag', 'antrag_id'],
+            'termin'         => [self::BELONGS_TO, 'Tagesordnungspunkt', 'termin_id'],
+            'rathausumschau' => [self::BELONGS_TO, 'Rathausumschau', 'rathausumschau_id'],
+            'ort'            => [self::BELONGS_TO, 'OrtGeo', 'ort_id'],
+        ];
     }
 
     /**
@@ -77,7 +77,7 @@ class AntragOrt extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                => 'ID',
             'antrag_id'         => 'Antrag',
             'termin_id'         => 'Termin',
@@ -87,6 +87,6 @@ class AntragOrt extends CActiveRecord
             'ort_id'            => 'Ort',
             'source'            => 'Source',
             'datum'             => 'Datum',
-        );
+        ];
     }
 }

--- a/protected/models/AntragPerson.php
+++ b/protected/models/AntragPerson.php
@@ -16,10 +16,10 @@ class AntragPerson extends CActiveRecord
 
     public static $TYP_GESTELLT_VON = "gestellt_von";
     public static $TYP_INITIATORIN = "initiator";
-    public static $TYPEN_ALLE = array(
+    public static $TYPEN_ALLE = [
         "gestellt_von" => "Gestellt von",
         "initiator"    => "InitiatorIn"
-    );
+    ];
 
 
     /**
@@ -47,11 +47,11 @@ class AntragPerson extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('antrag_id, person_id', 'required'),
-            array('antrag_id, person_id', 'numerical', 'integerOnly' => true),
-            array('typ', 'length', 'max' => 12),
-        );
+        return [
+            ['antrag_id, person_id', 'required'],
+            ['antrag_id, person_id', 'numerical', 'integerOnly' => true],
+            ['typ', 'length', 'max' => 12],
+        ];
     }
 
     /**
@@ -59,10 +59,10 @@ class AntragPerson extends CActiveRecord
      */
     public function relations()
     {
-        return array(
-            'person' => array(self::BELONGS_TO, 'Person', 'person_id'),
-            'antrag' => array(self::BELONGS_TO, 'Antrag', 'antrag_id'),
-        );
+        return [
+            'person' => [self::BELONGS_TO, 'Person', 'person_id'],
+            'antrag' => [self::BELONGS_TO, 'Antrag', 'antrag_id'],
+        ];
     }
 
     /**
@@ -70,12 +70,12 @@ class AntragPerson extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'antrag_id' => 'Antrag (ID)',
             'person_id' => 'Person (ID)',
             'antrag'    => 'Antrag',
             'person'    => 'Person',
             'typ'       => 'Typ',
-        );
+        ];
     }
 }

--- a/protected/models/BenutzerIn.php
+++ b/protected/models/BenutzerIn.php
@@ -22,11 +22,11 @@ class BenutzerIn extends CActiveRecord
     public static $BERECHTIGUNG_USER    = 1;
     public static $BERECHTIGUNG_CONTENT = 2;
     public static $BERECHTIGUNG_TAG     = 4;
-    public static $BERECHTIGUNGEN = array(
+    public static $BERECHTIGUNGEN = [
         1 => "User-Admin",
         2 => "Content-Admin",
         4 => "Tag-Admin",
-    );
+    ];
 
     /** @var null|BenutzerInnenEinstellungen */
     private $einstellungen_object = null;
@@ -37,7 +37,7 @@ class BenutzerIn extends CActiveRecord
      */
     public static function alleAktiveAccounts()
     {
-        return BenutzerIn::model()->findAllByAttributes(array("email_bestaetigt" => "1"), array("order" => "email"));
+        return BenutzerIn::model()->findAllByAttributes(["email_bestaetigt" => "1"], ["order" => "email"]);
     }
 
     /**
@@ -97,11 +97,11 @@ class BenutzerIn extends CActiveRecord
      */
     public function rules()
     {
-        $rules = array(
-            array('email, datum_angelegt', 'required'),
-            array('id, email_bestaetigt, berechtigungen_flags', 'numerical', 'integerOnly' => true),
-            array('datum_letzte_benachrichtigung', 'default', 'setOnEmpty' => true, 'value' => null),
-        );
+        $rules = [
+            ['email, datum_angelegt', 'required'],
+            ['id, email_bestaetigt, berechtigungen_flags', 'numerical', 'integerOnly' => true],
+            ['datum_letzte_benachrichtigung', 'default', 'setOnEmpty' => true, 'value' => null],
+        ];
         return $rules;
     }
 
@@ -110,10 +110,10 @@ class BenutzerIn extends CActiveRecord
      */
     public function relations()
     {
-        return array(
-            'abonnierte_vorgaenge' => array(self::MANY_MANY, 'Vorgang', 'benutzerInnen_vorgaenge_abos(benutzerInnen_id, vorgaenge_id)'),
-            'stadtraetInnen'       => array(self::HAS_MANY, 'StadtraetIn', 'benutzerIn_id'),
-        );
+        return [
+            'abonnierte_vorgaenge' => [self::MANY_MANY, 'Vorgang', 'benutzerInnen_vorgaenge_abos(benutzerInnen_id, vorgaenge_id)'],
+            'stadtraetInnen'       => [self::HAS_MANY, 'StadtraetIn', 'benutzerIn_id'],
+        ];
     }
 
     /**
@@ -121,7 +121,7 @@ class BenutzerIn extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                            => Yii::t('app', 'ID'),
             'email'                         => Yii::t('app', 'E-Mail'),
             'email_bestaetigt'              => Yii::t('app', 'E-Mail-Adresse bestätigt'),
@@ -133,7 +133,7 @@ class BenutzerIn extends CActiveRecord
             'einstellungen'                 => null,
             'abonnierte_vorgaenge'          => Yii::t('app', 'Abonnierte Vorgänge'),
             'berechtigungen_flags'          => 'Berechtigungen',
-        );
+        ];
     }
 
     /**
@@ -187,7 +187,7 @@ class BenutzerIn extends CActiveRecord
     public function sendEmailBestaetigungsMail()
     {
         $best_code = $this->createEmailBestaetigungsCode();
-        $link      = Yii::app()->getBaseUrl(true) . Yii::app()->createUrl("index/benachrichtigungen", array("code" => $best_code));
+        $link      = Yii::app()->getBaseUrl(true) . Yii::app()->createUrl("index/benachrichtigungen", ["code" => $best_code]);
         RISTools::send_email($this->email, "Anmeldung bei München Transparent", "Hallo,\n\num deine E-Mail-Adresse zu bestätigen und E-Mail-Benachrichtigungen von München Transparent zu erhalten, klicke bitte auf folgenden Link:\n$link\n\n"
             . "Liebe Grüße,\n\tDas München Transparent-Team.", null, "email");
     }
@@ -226,7 +226,7 @@ class BenutzerIn extends CActiveRecord
         $this->pwd_change_code = sha1(uniqid() . $this->pwd_enc);
         $this->pwd_change_date = new CDbExpression("NOW()");
         if ($this->save()) {
-            $link = Yii::app()->getBaseUrl(true) . Yii::app()->createUrl("benachrichtigungen/NeuesPasswortSetzen", array("id" => $this->id, "code" => $this->pwd_change_code));
+            $link = Yii::app()->getBaseUrl(true) . Yii::app()->createUrl("benachrichtigungen/NeuesPasswortSetzen", ["id" => $this->id, "code" => $this->pwd_change_code]);
             RISTools::send_email($this->email, "Passwort zurücksetzen", "Hallo,\n\num ein neues Passwort für deinen Zugang bei München Transparent zu setzen, klicke bitte auf folgenden Link:\n$link\n\n"
                 . "Liebe Grüße,\n\tDas München Transparent-Team.", null, "password");
             return true;
@@ -285,7 +285,7 @@ class BenutzerIn extends CActiveRecord
     {
         $suchkrits     = $krits->getBenachrichtigungKrits();
         $einstellungen = $this->getEinstellungen();
-        $neue          = array();
+        $neue          = [];
         foreach ($einstellungen->benachrichtigungen as $ben) if ($suchkrits->krits != $ben) $neue[] = $ben;
         $einstellungen->benachrichtigungen = $neue;
         $this->setEinstellungen($einstellungen);
@@ -297,7 +297,7 @@ class BenutzerIn extends CActiveRecord
      */
     public function getBenachrichtigungen()
     {
-        $arr           = array();
+        $arr           = [];
         $einstellungen = $this->getEinstellungen();
         foreach ($einstellungen->benachrichtigungen as $krit) $arr[] = new RISSucheKrits($krit);
         return $arr;
@@ -322,8 +322,8 @@ class BenutzerIn extends CActiveRecord
     public static function heuteZuBenachrichtigendeBenutzerInnen()
     {
         /** @var BenutzerIn[] $benutzerInnen */
-        $benutzerInnen = BenutzerIn::model()->findAllByAttributes(array("email_bestaetigt" => 1));
-        $todo          = array();
+        $benutzerInnen = BenutzerIn::model()->findAllByAttributes(["email_bestaetigt" => 1]);
+        $todo          = [];
         foreach ($benutzerInnen as $benutzerIn) {
             $wochentag = $benutzerIn->getEinstellungen()->benachrichtigungstag;
             if ($wochentag === null || $wochentag == date("w")) $todo[] = $benutzerIn;
@@ -363,12 +363,12 @@ class BenutzerIn extends CActiveRecord
         $ergebnisse = $solr->select($select);
         /** @var RISSolrDocument[] $documents */
         $documents = $ergebnisse->getDocuments();
-        $res       = array();
+        $res       = [];
         foreach ($documents as $document) {
-            $res[] = array(
+            $res[] = [
                 "id"   => $document->id,
                 "name" => $document->dokument_name . ", " . $document->antrag_betreff,
-            );
+            ];
         }
         return $res;
     }
@@ -389,18 +389,18 @@ class BenutzerIn extends CActiveRecord
             $neu_seit_ts = RISTools::date_iso2timestamp($neu_seit);
         }
 
-        $ergebnisse = array(
-            "antraege"  => array(),
-            "termine"   => array(),
-            "vorgaenge" => array(),
-        );
+        $ergebnisse = [
+            "antraege"  => [],
+            "termine"   => [],
+            "vorgaenge" => [],
+        ];
 
         $sql = Yii::app()->db->createCommand();
         $sql->select("id")->from("dokumente")->where("datum >= '" . addslashes($neu_seit) . "'");
-        $data = $sql->queryColumn(array("id"));
+        $data = $sql->queryColumn(["id"]);
         if (count($data) > 0) {
 
-            $document_ids = array();
+            $document_ids = [];
             foreach ($data as $did) $document_ids[] = "id:\"Document:$did\"";
 
             foreach ($benachrichtigungen as $benachrichtigung) {
@@ -412,30 +412,30 @@ class BenutzerIn extends CActiveRecord
                     if (!$dokument) continue;
                     if ($dokument->antrag_id > 0) {
                         if (!isset($ergebnisse["antraege"][$dokument->antrag_id])) {
-                            $ergebnisse["antraege"][$dokument->antrag_id] = array(
+                            $ergebnisse["antraege"][$dokument->antrag_id] = [
                                 "antrag"    => $dokument->antrag,
-                                "dokumente" => array()
-                            );
+                                "dokumente" => []
+                            ];
                         }
                         if (!isset($ergebnisse["antraege"][$dokument->antrag_id]["dokumente"][$dokument_id])) {
-                            $ergebnisse["antraege"][$dokument->antrag_id]["dokumente"][$dokument_id] = array(
+                            $ergebnisse["antraege"][$dokument->antrag_id]["dokumente"][$dokument_id] = [
                                 "dokument" => Dokument::model()->findByPk($dokument_id),
-                                "queries"  => array()
-                            );
+                                "queries"  => []
+                            ];
                         }
                         $ergebnisse["antraege"][$dokument->antrag_id]["dokumente"][$dokument_id]["queries"][] = $benachrichtigung;
                     } elseif ($dokument->termin_id > 0) {
                         if (!isset($ergebnisse["termine"][$dokument->termin_id])) {
-                            $ergebnisse["termine"][$dokument->termin_id] = array(
+                            $ergebnisse["termine"][$dokument->termin_id] = [
                                 "termin"    => $dokument->termin,
-                                "dokumente" => array()
-                            );
+                                "dokumente" => []
+                            ];
                         }
                         if (!isset($ergebnisse["termine"][$dokument->termin_id]["dokumente"][$dokument_id])) {
-                            $ergebnisse["termine"][$dokument->termin_id]["dokumente"][$dokument_id] = array(
+                            $ergebnisse["termine"][$dokument->termin_id]["dokumente"][$dokument_id] = [
                                 "dokument" => Dokument::model()->findByPk($dokument_id),
-                                "queries"  => array()
-                            );
+                                "queries"  => []
+                            ];
                         }
                         $ergebnisse["termine"][$dokument->termin_id]["dokumente"][$dokument_id]["queries"][] = $benachrichtigung;
                     }
@@ -446,18 +446,18 @@ class BenutzerIn extends CActiveRecord
         foreach ($this->abonnierte_vorgaenge as $vorgang) {
             foreach ($vorgang->antraege as $ant) {
                 if (RISTools::date_iso2timestamp($ant->datum_letzte_aenderung) < $neu_seit_ts) continue;
-                if (!isset($ergebnisse["vorgaenge"][$vorgang->id])) $ergebnisse["vorgaenge"][$vorgang->id] = array("vorgang" => $vorgang->wichtigstesRisItem()->getName(true), "neues" => array());
+                if (!isset($ergebnisse["vorgaenge"][$vorgang->id])) $ergebnisse["vorgaenge"][$vorgang->id] = ["vorgang" => $vorgang->wichtigstesRisItem()->getName(true), "neues" => []];
                 $ant->findeAenderungen(time());
                 $ergebnisse["vorgaenge"][$vorgang->id]["neues"][] = $ant;
             }
             foreach ($vorgang->dokumente as $dok) {
                 if (RISTools::date_iso2timestamp($dok->datum) < $neu_seit_ts) continue;
-                if (!isset($ergebnisse["vorgaenge"][$vorgang->id])) $ergebnisse["vorgaenge"][$vorgang->id] = array("vorgang" => $vorgang->wichtigstesRisItem()->getName(true), "neues" => array());
+                if (!isset($ergebnisse["vorgaenge"][$vorgang->id])) $ergebnisse["vorgaenge"][$vorgang->id] = ["vorgang" => $vorgang->wichtigstesRisItem()->getName(true), "neues" => []];
                 $ergebnisse["vorgaenge"][$vorgang->id]["neues"][] = $dok;
             }
             foreach ($vorgang->ergebnisse as $erg) {
                 if (RISTools::date_iso2timestamp($erg->datum_letzte_aenderung) < $neu_seit_ts) continue;
-                if (!isset($ergebnisse["vorgaenge"][$vorgang->id])) $ergebnisse["vorgaenge"][$vorgang->id] = array("vorgang" => $vorgang->wichtigstesRisItem()->getName(true), "neues" => array());
+                if (!isset($ergebnisse["vorgaenge"][$vorgang->id])) $ergebnisse["vorgaenge"][$vorgang->id] = ["vorgang" => $vorgang->wichtigstesRisItem()->getName(true), "neues" => []];
                 $ergebnisse["vorgaenge"][$vorgang->id]["neues"][] = $erg;
             }
         }

--- a/protected/models/BenutzerInnenEinstellungen.php
+++ b/protected/models/BenutzerInnenEinstellungen.php
@@ -4,7 +4,7 @@ class BenutzerInnenEinstellungen
 {
 
     /** @var array */
-    public $benachrichtigungen = array();
+    public $benachrichtigungen = [];
 
     /** @var null|int */
     public $benachrichtigungstag = null;

--- a/protected/models/Bezirksausschuss.php
+++ b/protected/models/Bezirksausschuss.php
@@ -47,11 +47,11 @@ class Bezirksausschuss extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('ba_nr, ris_id', 'required'),
-            array('ba_nr, ris_id, osm_init_zoom', 'numerical', 'integerOnly' => true),
-            array('name', 'length', 'max' => 100),
-        );
+        return [
+            ['ba_nr, ris_id', 'required'],
+            ['ba_nr, ris_id, osm_init_zoom', 'numerical', 'integerOnly' => true],
+            ['name', 'length', 'max' => 100],
+        ];
     }
 
     /**
@@ -61,16 +61,16 @@ class Bezirksausschuss extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'antraege'          => array(self::HAS_MANY, 'Antrag', 'ba_nr'),
-            'antraegeHistories' => array(self::HAS_MANY, 'AntragHistory', 'ba_nr'),
-            'gremien'           => array(self::HAS_MANY, 'Gremium', 'ba_nr'),
-            'gremienHistories'  => array(self::HAS_MANY, 'GremiumHistory', 'ba_nr'),
-            'RISAenderungen'    => array(self::HAS_MANY, 'RisAenderung', 'ba_nr'),
-            'stadtraetInnen'    => array(self::HAS_MANY, 'StadtraetIn', 'ba_nr'),
-            'fraktionen'        => array(self::HAS_MANY, 'Fraktion', 'ba_nr'),
-            'budgets'           => array(self::HAS_MANY, 'BezirksausschussBudget', 'ba_nr'),
-        );
+        return [
+            'antraege'          => [self::HAS_MANY, 'Antrag', 'ba_nr'],
+            'antraegeHistories' => [self::HAS_MANY, 'AntragHistory', 'ba_nr'],
+            'gremien'           => [self::HAS_MANY, 'Gremium', 'ba_nr'],
+            'gremienHistories'  => [self::HAS_MANY, 'GremiumHistory', 'ba_nr'],
+            'RISAenderungen'    => [self::HAS_MANY, 'RisAenderung', 'ba_nr'],
+            'stadtraetInnen'    => [self::HAS_MANY, 'StadtraetIn', 'ba_nr'],
+            'fraktionen'        => [self::HAS_MANY, 'Fraktion', 'ba_nr'],
+            'budgets'           => [self::HAS_MANY, 'BezirksausschussBudget', 'ba_nr'],
+        ];
     }
 
     /**
@@ -78,7 +78,7 @@ class Bezirksausschuss extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'ba_nr'         => 'BA Nr',
             'ris_id'        => "RIS ID",
             'name'          => 'Name',
@@ -86,25 +86,25 @@ class Bezirksausschuss extends CActiveRecord
             'osm_init_zoom' => 'OSM Zoom',
             'osm_shape'     => 'OSM Shape',
             'budgets'       => 'Budgets',
-        );
+        ];
     }
 
 
     public function toGeoJSONArray()
     {
-        return array(
+        return [
             "type"       => "Feature",
             "id"         => $this->ba_nr,
-            "properties" => array(
+            "properties" => [
                 "name"    => $this->name,
                 "website" => $this->website
-            ),
+            ],
             "init_zoom"  => IntVal($this->osm_init_zoom),
-            "geometry"   => array(
+            "geometry"   => [
                 "type"        => "Polygon",
-                "coordinates" => array(json_decode($this->osm_shape))
-            )
-        );
+                "coordinates" => [json_decode($this->osm_shape)]
+            ]
+        ];
     }
 
 
@@ -168,9 +168,9 @@ class Bezirksausschuss extends CActiveRecord
             }
         }
         if (!$vollgremium) {
-            return array();
+            return [];
         }
-        $funktionen = array();
+        $funktionen = [];
         foreach ($vollgremium->mitgliedschaften as $mitgliedschaft) {
             if (mb_stripos($mitgliedschaft->funktion, "Mitgl") === 0) {
                 continue;
@@ -183,10 +183,10 @@ class Bezirksausschuss extends CActiveRecord
 
         $funktion2weight = function ($funktion) {
             $funktion = trim($funktion);
-            if (in_array($funktion, array("Vorsitz", "BA-Vorsitz", "BA-Vorsitzender", "BA-Vorsitzende", "Vorsitzender", "Vorsitzende", "Sitzungsleitung"))) {
+            if (in_array($funktion, ["Vorsitz", "BA-Vorsitz", "BA-Vorsitzender", "BA-Vorsitzende", "Vorsitzender", "Vorsitzende", "Sitzungsleitung"])) {
                 return 1;
             }
-            if (mb_stripos($funktion, "1. stell") === 0 || mb_stripos($funktion, "1. stv") === 0 || in_array($funktion, array("stellv. Vorsitz"))) {
+            if (mb_stripos($funktion, "1. stell") === 0 || mb_stripos($funktion, "1. stv") === 0 || in_array($funktion, ["stellv. Vorsitz"])) {
                 return 2;
             }
             if (mb_stripos($funktion, "2. stell") === 0 || mb_stripos($funktion, "2. stv") === 0) {
@@ -212,7 +212,7 @@ class Bezirksausschuss extends CActiveRecord
     /** @return string */
     public function getLink()
     {
-        return Yii::app()->createUrl("index/ba", array("ba_nr" => $this->ba_nr, "ba_name" => $this->name));
+        return Yii::app()->createUrl("index/ba", ["ba_nr" => $this->ba_nr, "ba_name" => $this->name]);
     }
 
 
@@ -223,14 +223,14 @@ class Bezirksausschuss extends CActiveRecord
     {
         //return array(); // @TODO
 
-        $statistiken = array();
+        $statistiken = [];
 
-        $daten = StatistikDatensatz::model()->findByAttributes(array("gliederung_nummer" => $this->ba_nr, "basiswert_2_name" => "Anzahl aller Einwohner (gesamt)"), array("order" => "jahr DESC"));
+        $daten = StatistikDatensatz::model()->findByAttributes(["gliederung_nummer" => $this->ba_nr, "basiswert_2_name" => "Anzahl aller Einwohner (gesamt)"], ["order" => "jahr DESC"]);
         if ($daten) {
-            $statistiken[] = array(
+            $statistiken[] = [
                 "name" => "EinwohnerInnen",
                 "wert" => $daten->basiswert_2,
-            );
+            ];
         }
 
         return $statistiken;

--- a/protected/models/BezirksausschussBudget.php
+++ b/protected/models/BezirksausschussBudget.php
@@ -37,11 +37,11 @@ class BezirksausschussBudget extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('ba_nr, jahr, budget, vorjahr_rest', 'required'),
-            array('ba_nr, jahr, budget, vorjahr_rest, cache_aktuell', 'numerical', 'integerOnly' => true),
-            array('budget, vorjahr_rest, cache_aktuell', 'safe'),
-        );
+        return [
+            ['ba_nr, jahr, budget, vorjahr_rest', 'required'],
+            ['ba_nr, jahr, budget, vorjahr_rest, cache_aktuell', 'numerical', 'integerOnly' => true],
+            ['budget, vorjahr_rest, cache_aktuell', 'safe'],
+        ];
     }
 
     /**
@@ -51,9 +51,9 @@ class BezirksausschussBudget extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'bezirksausschuss' => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-        );
+        return [
+            'bezirksausschuss' => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+        ];
     }
 
     /**
@@ -61,12 +61,12 @@ class BezirksausschussBudget extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'ba_nr'         => 'Bezirksausschuss Nr.',
             'jahr'          => 'Jahr',
             'budget'        => 'Jahresbudget',
             'vorjahr_rest'  => 'Übertrag d. Vorjahr',
             'cache_aktuell' => 'Aktuelles Restguthaben',
-        );
+        ];
     }
 }

--- a/protected/models/Dokument.php
+++ b/protected/models/Dokument.php
@@ -50,7 +50,7 @@ class Dokument extends CActiveRecord implements IRISItem
     public static $TYP_BA_BESCHLUSS       = "ba_beschluss";
     public static $TYP_RATHAUSUMSCHAU     = "rathausumschau";
     //public static $TYP_BV_EMPFEHLUNG = "bv_empfehlung"; @TODO
-    public static $TYPEN_ALLE = array(
+    public static $TYPEN_ALLE = [
         "stadtrat_antrag"    => "Stadtratsantrag",
         "stadtrat_vorlage"   => "Stadtratsvorlage",
         "stadtrat_termin"    => "Stadtrat: Termin",
@@ -61,12 +61,12 @@ class Dokument extends CActiveRecord implements IRISItem
         "ba_beschluss"       => "BA: Beschluss",
         "rathausumschau"     => "Rathausumschau",
         //"bv_empfehlung"      => "BürgerInnenversammlung: Empfehlung",
-    );
+    ];
 
     public static $OCR_VON_TESSERACT = "tesseract";
     public static $OCR_VON_OMNIPAGE  = "omnipage";
 
-    private static $_cache = array();
+    private static $_cache = [];
 
     /**
      * Returns the static model of the specified AR class.
@@ -93,14 +93,14 @@ class Dokument extends CActiveRecord implements IRISItem
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, url, name, datum', 'required'),
-            array('id, antrag_id, termin_id, tagesordnungspunkt_id, rathausumschau_id, deleted, seiten_anzahl, vorgang_id', 'numerical', 'integerOnly' => true),
-            array('typ', 'length', 'max' => 25),
-            array('url', 'length', 'max' => 500),
-            array('name, name_title', 'length', 'max' => 300),
-            array('text_ocr_raw, text_ocr_corrected, text_ocr_garbage_seiten, text_pdf, ocr_von, highlight, name, name_title', 'safe'),
-        );
+        return [
+            ['id, url, name, datum', 'required'],
+            ['id, antrag_id, termin_id, tagesordnungspunkt_id, rathausumschau_id, deleted, seiten_anzahl, vorgang_id', 'numerical', 'integerOnly' => true],
+            ['typ', 'length', 'max' => 25],
+            ['url', 'length', 'max' => 500],
+            ['name, name_title', 'length', 'max' => 300],
+            ['text_ocr_raw, text_ocr_corrected, text_ocr_garbage_seiten, text_pdf, ocr_von, highlight, name, name_title', 'safe'],
+        ];
     }
 
     /**
@@ -110,14 +110,14 @@ class Dokument extends CActiveRecord implements IRISItem
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'vorgang_id'         => array(self::BELONGS_TO, 'Vorgang', 'id'),
-            'antrag'             => array(self::BELONGS_TO, 'Antrag', 'antrag_id'),
-            'termin'             => array(self::BELONGS_TO, 'Termin', 'termin_id'),
-            'tagesordnungspunkt' => array(self::BELONGS_TO, 'Tagesordnungspunkt', 'tagesordnungspunkt_id'),
-            'rathausumschau'     => array(self::BELONGS_TO, 'Rathausumschau', 'rathausumschau_id'),
-            'orte'               => array(self::HAS_MANY, 'AntragOrt', 'dokument_id'),
-        );
+        return [
+            'vorgang_id'         => [self::BELONGS_TO, 'Vorgang', 'id'],
+            'antrag'             => [self::BELONGS_TO, 'Antrag', 'antrag_id'],
+            'termin'             => [self::BELONGS_TO, 'Termin', 'termin_id'],
+            'tagesordnungspunkt' => [self::BELONGS_TO, 'Tagesordnungspunkt', 'tagesordnungspunkt_id'],
+            'rathausumschau'     => [self::BELONGS_TO, 'Rathausumschau', 'rathausumschau_id'],
+            'orte'               => [self::HAS_MANY, 'AntragOrt', 'dokument_id'],
+        ];
     }
 
     /**
@@ -125,7 +125,7 @@ class Dokument extends CActiveRecord implements IRISItem
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                      => 'ID',
             'vorgang_id'              => 'Vorgangs-ID',
             'typ'                     => 'Typ',
@@ -144,24 +144,24 @@ class Dokument extends CActiveRecord implements IRISItem
             'text_ocr_garbage_seiten' => 'Text Ocr Garbage Seiten',
             'text_pdf'                => 'Text Pdf',
             'seiten_anzahl'           => 'Seitenanzahl',
-        );
+        ];
     }
 
     public function behaviors()
     {
-        return array(
-            'CTimestampBehavior' => array(
+        return [
+            'CTimestampBehavior' => [
                 'class' => 'DisableDefaultScopeBehavior',
-            )
-        );
+            ]
+        ];
     }
 
     public function defaultScope()
     {
         $alias = $this->getTableAlias(false, false);
-        return $this->getDefaultScopeDisabled() ? array() : array(
+        return $this->getDefaultScopeDisabled() ? [] : [
             'condition' => $alias . ".deleted = 0",
-        );
+        ];
 
     }
 
@@ -182,10 +182,10 @@ class Dokument extends CActiveRecord implements IRISItem
      */
     public function neueste($limit)
     {
-        $this->getDbCriteria()->mergeWith(array(
+        $this->getDbCriteria()->mergeWith([
             'order' => 'datum DESC',
             'limit' => $limit,
-        ));
+        ]);
         return $this;
     }
 
@@ -194,7 +194,7 @@ class Dokument extends CActiveRecord implements IRISItem
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
         if ($this->typ == static::$TYP_RATHAUSUMSCHAU) {
             if ($this->rathausumschau->datum >= 2009) return "http://www.muenchen.de" . $this->url;
@@ -320,12 +320,12 @@ class Dokument extends CActiveRecord implements IRISItem
         $strassen_gefunden = RISGeo::suche_strassen($text);
 
         /** @var array|AntragOrt[] $bisherige */
-        $bisherige     = AntragOrt::model()->findAllByAttributes(array("dokument_id" => $this->id));
-        $bisherige_ids = array();
+        $bisherige     = AntragOrt::model()->findAllByAttributes(["dokument_id" => $this->id]);
+        $bisherige_ids = [];
         foreach ($bisherige as $i) $bisherige_ids[] = $i->ort_id;
 
-        $neue_ids = array();
-        $indexed  = array();
+        $neue_ids = [];
+        $indexed  = [];
 
         foreach ($strassen_gefunden as $strasse_name) if (!in_array($strasse_name, $indexed)) {
             $indexed[] = $strasse_name;
@@ -357,10 +357,10 @@ class Dokument extends CActiveRecord implements IRISItem
         }
 
         foreach ($bisherige_ids as $id) if (!in_array($id, $neue_ids)) {
-            AntragOrt::model()->deleteAllByAttributes(array("dokument_id" => $this->id, "ort_id" => $id));
+            AntragOrt::model()->deleteAllByAttributes(["dokument_id" => $this->id, "ort_id" => $id]);
         }
 
-        $this->orte = AntragOrt::model()->findAllByAttributes(array("dokument_id" => $this->id));
+        $this->orte = AntragOrt::model()->findAllByAttributes(["dokument_id" => $this->id]);
     }
 
 
@@ -460,11 +460,11 @@ class Dokument extends CActiveRecord implements IRISItem
      */
     public function getLinkZumDokument()
     {
-        return Yii::app()->createUrl("index/dokumente", array("id" => $this->id));
+        return Yii::app()->createUrl("index/dokumente", ["id" => $this->id]);
     }
 
 
-    private static $dokumente_cache = array();
+    private static $dokumente_cache = [];
 
     /**
      * @param string $id
@@ -479,7 +479,7 @@ class Dokument extends CActiveRecord implements IRISItem
             if (!isset(static::$dokumente_cache[$id])) static::$dokumente_cache[$id] = Dokument::model()->with("antrag")->findByPk($id);
             return static::$dokumente_cache[$id];
         }
-        return Dokument::model()->with(array("antrag", "tagesordnungspunkt", "rathausumschau"))->findByPk($id);
+        return Dokument::model()->with(["antrag", "tagesordnungspunkt", "rathausumschau"])->findByPk($id);
     }
 
     /**
@@ -487,9 +487,9 @@ class Dokument extends CActiveRecord implements IRISItem
      */
     public function getRISItem()
     {
-        if (in_array($this->typ, array(static::$TYP_STADTRAT_BESCHLUSS, static::$TYP_BA_BESCHLUSS))) return $this->tagesordnungspunkt;
-        if (in_array($this->typ, array(static::$TYP_STADTRAT_TERMIN, static::$TYP_BA_TERMIN))) return $this->termin;
-        if (in_array($this->typ, array(static::$TYP_RATHAUSUMSCHAU))) return $this->rathausumschau;
+        if (in_array($this->typ, [static::$TYP_STADTRAT_BESCHLUSS, static::$TYP_BA_BESCHLUSS])) return $this->tagesordnungspunkt;
+        if (in_array($this->typ, [static::$TYP_STADTRAT_TERMIN, static::$TYP_BA_TERMIN])) return $this->termin;
+        if (in_array($this->typ, [static::$TYP_RATHAUSUMSCHAU])) return $this->rathausumschau;
         return $this->antrag;
     }
 
@@ -504,14 +504,14 @@ class Dokument extends CActiveRecord implements IRISItem
      */
     public function solrMoreLikeThis($limit = 10)
     {
-        if ($GLOBALS["SOLR_CONFIG"] === null) return array();
+        if ($GLOBALS["SOLR_CONFIG"] === null) return [];
         $solr   = RISSolrHelper::getSolrClient("ris");
         $select = $solr->createSelect();
         $select->setQuery("id:\"Document:" . $this->id . "\"");
         $select->getMoreLikeThis()->setFields("text")->setMinimumDocumentFrequency(1)->setMinimumTermFrequency(1)->setCount($limit);
         $ergebnisse = $solr->select($select);
         $mlt        = $ergebnisse->getMoreLikeThis();
-        $ret        = array();
+        $ret        = [];
         foreach ($ergebnisse as $document) {
             $mltResult = $mlt->getResult($document->id);
             if ($mltResult) foreach ($mltResult as $mltDoc) {
@@ -543,8 +543,8 @@ class Dokument extends CActiveRecord implements IRISItem
         $doc->termin_datum       = RISSolrHelper::mysql2solrDate($this->termin->termin);
         $max_datum               = $this->termin->termin;
 
-        $geo            = array();
-        $dokument_bas   = array();
+        $geo            = [];
+        $dokument_bas   = [];
         $dokument_bas[] = ($this->termin->ba_nr > 0 ? $this->termin->ba_nr : 0);
         foreach ($this->orte as $ort) if ($ort->ort->to_hide == 0) {
             $geo[] = $ort->ort->lat . "," . $ort->ort->lon;
@@ -553,10 +553,10 @@ class Dokument extends CActiveRecord implements IRISItem
         $doc->geo          = $geo;
         $doc->dokument_bas = $dokument_bas;
 
-        $aenderungs_datum = array();
+        $aenderungs_datum = [];
 
         /** @var array|RISAenderung[] $aenderungen */
-        $aenderungen = RISAenderung::model()->findAllByAttributes(array("ris_id" => $this->antrag_id), array("order" => "datum DESC"));
+        $aenderungen = RISAenderung::model()->findAllByAttributes(["ris_id" => $this->antrag_id], ["order" => "datum DESC"]);
         foreach ($aenderungen as $o) {
             $aenderungs_datum[] = RISSolrHelper::mysql2solrDate($o->datum);
             $max_datum          = $o->datum;
@@ -566,7 +566,7 @@ class Dokument extends CActiveRecord implements IRISItem
 
         if ($max_datum != "") $doc->sort_datum = RISSolrHelper::mysql2solrDate($max_datum);
 
-        $update->addDocuments(array($doc));
+        $update->addDocuments([$doc]);
 
     }
 
@@ -595,7 +595,7 @@ class Dokument extends CActiveRecord implements IRISItem
         $doc->antrag_betreff     = RISSolrHelper::string_cleanup($this->antrag->betreff);
         $doc->referat_id         = $this->antrag->referat_id;
 
-        $antrag_erstellt = $aenderungs_datum = array();
+        $antrag_erstellt = $aenderungs_datum = [];
         if (preg_match("/^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$/", $this->antrag->gestellt_am)) {
             $antrag_erstellt[]  = RISSolrHelper::mysql2solrDate($this->antrag->gestellt_am . " 12:00:00");
             $aenderungs_datum[] = RISSolrHelper::mysql2solrDate($this->antrag->gestellt_am . " 12:00:00");
@@ -603,8 +603,8 @@ class Dokument extends CActiveRecord implements IRISItem
         }
 
 
-        $geo            = array();
-        $dokument_bas   = array();
+        $geo            = [];
+        $dokument_bas   = [];
         $dokument_bas[] = ($this->antrag->ba_nr > 0 ? $this->antrag->ba_nr : 0);
         foreach ($this->orte as $ort) if ($ort->ort->to_hide == 0) {
             $geo[] = $ort->ort->lat . "," . $ort->ort->lon;
@@ -614,7 +614,7 @@ class Dokument extends CActiveRecord implements IRISItem
         $doc->dokument_bas = $dokument_bas;
 
         /** @var array|RISAenderung[] $aenderungen */
-        $aenderungen = RISAenderung::model()->findAllByAttributes(array("ris_id" => $this->antrag_id), array("order" => "datum DESC"));
+        $aenderungen = RISAenderung::model()->findAllByAttributes(["ris_id" => $this->antrag_id], ["order" => "datum DESC"]);
         foreach ($aenderungen as $o) {
             $aenderungs_datum[] = RISSolrHelper::mysql2solrDate($o->datum);
             $max_datum          = $o->datum;
@@ -626,7 +626,7 @@ class Dokument extends CActiveRecord implements IRISItem
 
 
         if ($max_datum != "") $doc->sort_datum = RISSolrHelper::mysql2solrDate($max_datum);
-        $update->addDocuments(array($doc));
+        $update->addDocuments([$doc]);
     }
 
 
@@ -647,8 +647,8 @@ class Dokument extends CActiveRecord implements IRISItem
         $doc->dokument_url  = $this->url;
         $doc->antrag_id     = $this->rathausumschau->nr;
 
-        $geo          = array();
-        $dokument_bas = array();
+        $geo          = [];
+        $dokument_bas = [];
         foreach ($this->orte as $ort) if ($ort->ort->to_hide == 0) {
             $geo[] = $ort->ort->lat . "," . $ort->ort->lon;
             if ($ort->ort->ba_nr > 0 && !in_array($ort->ort->ba_nr, $dokument_bas)) $dokument_bas[] = $ort->ort->ba_nr;
@@ -657,7 +657,7 @@ class Dokument extends CActiveRecord implements IRISItem
         $doc->dokument_bas = $dokument_bas;
 
         $doc->sort_datum = RISSolrHelper::mysql2solrDate($this->rathausumschau->datum . " 13:00:00");
-        $update->addDocuments(array($doc));
+        $update->addDocuments([$doc]);
     }
 
 
@@ -677,8 +677,8 @@ class Dokument extends CActiveRecord implements IRISItem
         $doc->dokument_name = RISSolrHelper::string_cleanup($this->name);
         $doc->dokument_url  = $this->url;
 
-        $geo          = array();
-        $dokument_bas = array();
+        $geo          = [];
+        $dokument_bas = [];
         foreach ($this->orte as $ort) if ($ort->ort->to_hide == 0) {
             $geo[] = $ort->ort->lat . "," . $ort->ort->lon;
             if ($ort->ort->ba_nr > 0 && !in_array($ort->ort->ba_nr, $dokument_bas)) $dokument_bas[] = $ort->ort->ba_nr;
@@ -688,7 +688,7 @@ class Dokument extends CActiveRecord implements IRISItem
 
         $datum           = $this->getDate();
         $doc->sort_datum = RISSolrHelper::mysql2solrDate($datum);
-        $update->addDocuments(array($doc));
+        $update->addDocuments([$doc]);
     }
 
 
@@ -710,8 +710,8 @@ class Dokument extends CActiveRecord implements IRISItem
                 }
 
             } else {
-                if (in_array($this->typ, array(static::$TYP_STADTRAT_TERMIN, static::$TYP_BA_TERMIN))) $this->solrIndex_termin_do($update);
-                elseif (in_array($this->typ, array(static::$TYP_STADTRAT_BESCHLUSS, static::$TYP_BA_BESCHLUSS))) $this->solrIndex_beschluss_do($update);
+                if (in_array($this->typ, [static::$TYP_STADTRAT_TERMIN, static::$TYP_BA_TERMIN])) $this->solrIndex_termin_do($update);
+                elseif (in_array($this->typ, [static::$TYP_STADTRAT_BESCHLUSS, static::$TYP_BA_BESCHLUSS])) $this->solrIndex_beschluss_do($update);
                 elseif ($this->typ == static::$TYP_RATHAUSUMSCHAU) $this->solrIndex_rathausumschau_do($update);
                 else $this->solrIndex_antrag_do($update);
             }
@@ -731,7 +731,7 @@ class Dokument extends CActiveRecord implements IRISItem
      */
     public static function getHighlightDokumente($limit = 3)
     {
-        return Dokument::model()->findAll(array("condition" => "highlight IS NOT NULL", "order" => "highlight DESC", "limit" => $limit));
+        return Dokument::model()->findAll(["condition" => "highlight IS NOT NULL", "order" => "highlight DESC", "limit" => $limit]);
     }
 
     /**

--- a/protected/models/Fraktion.php
+++ b/protected/models/Fraktion.php
@@ -41,12 +41,12 @@ class Fraktion extends CActiveRecord implements IRISItem
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, name', 'required'),
-            array('id, ba_nr', 'numerical', 'integerOnly' => true),
-            array('name', 'length', 'max' => 70),
-            array('website', 'length', 'max' => 250),
-        );
+        return [
+            ['id, name', 'required'],
+            ['id, ba_nr', 'numerical', 'integerOnly' => true],
+            ['name', 'length', 'max' => 70],
+            ['website', 'length', 'max' => 250],
+        ];
     }
 
     /**
@@ -56,11 +56,11 @@ class Fraktion extends CActiveRecord implements IRISItem
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'stadtraetInnenFraktionen' => array(self::HAS_MANY, 'StadtraetInFraktion', 'fraktion_id'),
-            'bezirksausschuss'         => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-            'personen'                 => array(self::HAS_MANY, 'Person', 'ris_fraktion'),
-        );
+        return [
+            'stadtraetInnenFraktionen' => [self::HAS_MANY, 'StadtraetInFraktion', 'fraktion_id'],
+            'bezirksausschuss'         => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+            'personen'                 => [self::HAS_MANY, 'Person', 'ris_fraktion'],
+        ];
     }
 
     /**
@@ -68,18 +68,18 @@ class Fraktion extends CActiveRecord implements IRISItem
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'    => 'ID',
             'ba_nr' => "BA-Nr",
             'name'  => 'Name',
-        );
+        ];
     }
 
     /**
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
         if ($this->id < 0) return "#";
         $strs = $this->stadtraetInnenFraktionen;
@@ -101,9 +101,9 @@ class Fraktion extends CActiveRecord implements IRISItem
         $name = RISTools::korrigiereTitelZeichen($this->name);
         if ($name == "&nbsp;" || trim($name) == "") return "fraktionslos";
         if ($kurzfassung) {
-            if (in_array($this->id, array(3339564, 2988265, 3312425))) return "Bürgerliche Mitte";
+            if (in_array($this->id, [3339564, 2988265, 3312425])) return "Bürgerliche Mitte";
             if ($this->id == 3312427) return "Freiheitsrechte Transparenz Bürgerbeteiligung";
-            if (in_array($this->id, array(3312426, 1431959, 33))) return "Die Grünen / RL";
+            if (in_array($this->id, [3312426, 1431959, 33])) return "Die Grünen / RL";
         }
         return $name;
     }

--- a/protected/models/Gremium.php
+++ b/protected/models/Gremium.php
@@ -45,12 +45,12 @@ class Gremium extends CActiveRecord implements IRISItem
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, datum_letzte_aenderung, name, kuerzel, gremientyp', 'required'),
-            array('id, ba_nr', 'numerical', 'integerOnly' => true),
-            array('name, gremientyp, referat', 'length', 'max' => 100),
-            array('kuerzel', 'length', 'max' => 50),
-        );
+        return [
+            ['id, datum_letzte_aenderung, name, kuerzel, gremientyp', 'required'],
+            ['id, ba_nr', 'numerical', 'integerOnly' => true],
+            ['name, gremientyp, referat', 'length', 'max' => 100],
+            ['kuerzel', 'length', 'max' => 50],
+        ];
     }
 
     /**
@@ -60,12 +60,12 @@ class Gremium extends CActiveRecord implements IRISItem
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'tagesordnungspunkte' => array(self::HAS_MANY, 'Tagesordnungspunkt', 'gremium_id'),
-            'ba'                  => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-            'termine'             => array(self::HAS_MANY, 'Termin', 'gremium_id'),
-            'mitgliedschaften'    => array(self::HAS_MANY, 'StadtraetInGremium', 'gremium_id'),
-        );
+        return [
+            'tagesordnungspunkte' => [self::HAS_MANY, 'Tagesordnungspunkt', 'gremium_id'],
+            'ba'                  => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+            'termine'             => [self::HAS_MANY, 'Termin', 'gremium_id'],
+            'mitgliedschaften'    => [self::HAS_MANY, 'StadtraetInGremium', 'gremium_id'],
+        ];
     }
 
     /**
@@ -73,7 +73,7 @@ class Gremium extends CActiveRecord implements IRISItem
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                     => 'ID',
             'datum_letzte_aenderung' => 'Datum Letzte Aenderung',
             'ba_nr'                  => 'Ba Nr',
@@ -81,7 +81,7 @@ class Gremium extends CActiveRecord implements IRISItem
             'kuerzel'                => 'Kuerzel',
             'gremientyp'             => 'Gremientyp',
             'referat'                => 'Referat',
-        );
+        ];
     }
 
     /**
@@ -169,9 +169,9 @@ class Gremium extends CActiveRecord implements IRISItem
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
-        return Yii::app()->createUrl("gremium/anzeigen", array_merge(array("id" => $this->id), $add_params));
+        return Yii::app()->createUrl("gremium/anzeigen", array_merge(["id" => $this->id], $add_params));
     }
 
 

--- a/protected/models/GremiumHistory.php
+++ b/protected/models/GremiumHistory.php
@@ -42,12 +42,12 @@ class GremiumHistory extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, datum_letzte_aenderung, name, kuerzel, gremientyp, referat', 'required'),
-            array('id, ba_nr', 'numerical', 'integerOnly' => true),
-            array('name, gremientyp, referat', 'length', 'max' => 100),
-            array('kuerzel', 'length', 'max' => 20),
-        );
+        return [
+            ['id, datum_letzte_aenderung, name, kuerzel, gremientyp, referat', 'required'],
+            ['id, ba_nr', 'numerical', 'integerOnly' => true],
+            ['name, gremientyp, referat', 'length', 'max' => 100],
+            ['kuerzel', 'length', 'max' => 20],
+        ];
     }
 
     /**
@@ -57,9 +57,9 @@ class GremiumHistory extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'ba' => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-        );
+        return [
+            'ba' => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+        ];
     }
 
     /**
@@ -67,7 +67,7 @@ class GremiumHistory extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                     => 'ID',
             'datum_letzte_aenderung' => 'Datum Letzte Aenderung',
             'ba_nr'                  => 'Ba Nr',
@@ -75,6 +75,6 @@ class GremiumHistory extends CActiveRecord
             'kuerzel'                => 'Kuerzel',
             'gremientyp'             => 'Gremientyp',
             'referat'                => 'Referat',
-        );
+        ];
     }
 }

--- a/protected/models/IRISItem.php
+++ b/protected/models/IRISItem.php
@@ -7,7 +7,7 @@ interface IRISItem
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array());
+    public function getLink($add_params = []);
 
     /** @return string */
     public function getTypName();

--- a/protected/models/OrtGeo.php
+++ b/protected/models/OrtGeo.php
@@ -44,14 +44,14 @@ class OrtGeo extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('ort, lat, lon, source, to_hide, datum', 'required'),
-            array('to_hide, ba_nr', 'numerical', 'integerOnly' => true),
-            array('lat, lon', 'numerical'),
-            array('ort', 'length', 'max' => 100),
-            array('source', 'length', 'max' => 6),
-            array('to_hide_kommentar', 'length', 'max' => 200),
-        );
+        return [
+            ['ort, lat, lon, source, to_hide, datum', 'required'],
+            ['to_hide, ba_nr', 'numerical', 'integerOnly' => true],
+            ['lat, lon', 'numerical'],
+            ['ort', 'length', 'max' => 100],
+            ['source', 'length', 'max' => 6],
+            ['to_hide_kommentar', 'length', 'max' => 200],
+        ];
     }
 
     /**
@@ -61,9 +61,9 @@ class OrtGeo extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'antraegeOrte' => array(self::HAS_MANY, 'AntragOrt', 'ort_id'),
-        );
+        return [
+            'antraegeOrte' => [self::HAS_MANY, 'AntragOrt', 'ort_id'],
+        ];
     }
 
     /**
@@ -71,7 +71,7 @@ class OrtGeo extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                => 'ID',
             'ort'               => 'Ort',
             'lat'               => 'Lat',
@@ -80,7 +80,7 @@ class OrtGeo extends CActiveRecord
             'to_hide'           => 'To Hide',
             'to_hide_kommentar' => 'To Hide Kommentar',
             'datum'             => 'Datum',
-        );
+        ];
     }
 
     /**
@@ -91,7 +91,7 @@ class OrtGeo extends CActiveRecord
     public static function getOrCreate($name)
     {
         /** @var null|OrtGeo */
-        $ort = OrtGeo::model()->findByAttributes(array("ort" => $name));
+        $ort = OrtGeo::model()->findByAttributes(["ort" => $name]);
         if ($ort) return $ort;
 
         $data = RISGeo::addressToGeo("Deutschland", "", "München", $name);

--- a/protected/models/Person.php
+++ b/protected/models/Person.php
@@ -22,11 +22,11 @@ class Person extends CActiveRecord implements IRISItem
     public static $TYP_SONSTIGES = "sonstiges";
     public static $TYP_PERSON = "person";
     public static $TYP_FRAKTION = "fraktion";
-    public static $TYPEN_ALLE = array(
+    public static $TYPEN_ALLE = [
         "sonstiges" => "Sonstiges / Unbekannt",
         "person"    => "Person",
         "fraktion"  => "Fraktion"
-    );
+    ];
 
     /**
      * @param string $className active record class name.
@@ -50,12 +50,12 @@ class Person extends CActiveRecord implements IRISItem
      */
     public function rules()
     {
-        return array(
-            array('name_normalized, typ, name', 'required'),
-            array('ris_stadtraetIn, ris_fraktion', 'numerical', 'integerOnly' => true),
-            array('typ', 'length', 'max' => 9),
-            array('name, name_normalized', 'length', 'max' => 100),
-        );
+        return [
+            ['name_normalized, typ, name', 'required'],
+            ['ris_stadtraetIn, ris_fraktion', 'numerical', 'integerOnly' => true],
+            ['typ', 'length', 'max' => 9],
+            ['name, name_normalized', 'length', 'max' => 100],
+        ];
     }
 
     /**
@@ -63,11 +63,11 @@ class Person extends CActiveRecord implements IRISItem
      */
     public function relations()
     {
-        return array(
-            'antraegePersonen' => array(self::HAS_MANY, 'AntragPerson', 'person_id'),
-            'stadtraetIn'      => array(self::BELONGS_TO, 'StadtraetIn', 'ris_stadtraetIn'),
-            'fraktion'         => array(self::BELONGS_TO, 'Fraktion', 'ris_fraktion'),
-        );
+        return [
+            'antraegePersonen' => [self::HAS_MANY, 'AntragPerson', 'person_id'],
+            'stadtraetIn'      => [self::BELONGS_TO, 'StadtraetIn', 'ris_stadtraetIn'],
+            'fraktion'         => [self::BELONGS_TO, 'Fraktion', 'ris_fraktion'],
+        ];
     }
 
     /**
@@ -75,14 +75,14 @@ class Person extends CActiveRecord implements IRISItem
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'              => 'ID',
             'name_normalized' => 'Name Normalized',
             'typ'             => 'Typ',
             'name'            => 'Name',
             'ris_stadtraetIn' => 'StadträtInnen-ID',
             'ris_fraktion'    => 'Fraktion',
-        );
+        ];
     }
 
     /**
@@ -94,7 +94,7 @@ class Person extends CActiveRecord implements IRISItem
     public static function getOrCreate($name, $name_normalized)
     {
         /** @var Person|null $pers */
-        $pers = Person::model()->findByAttributes(array("name_normalized" => $name_normalized));
+        $pers = Person::model()->findByAttributes(["name_normalized" => $name_normalized]);
         if (is_null($pers)) {
             $pers                  = new Person();
             $pers->name            = $name;
@@ -128,9 +128,9 @@ class Person extends CActiveRecord implements IRISItem
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
-        return Yii::app()->createUrl("personen/person", array_merge(array("id" => $this->id, "name" => $this->name), $add_params));
+        return Yii::app()->createUrl("personen/person", array_merge(["id" => $this->id, "name" => $this->name], $add_params));
     }
 
     /** @return string */
@@ -146,7 +146,7 @@ class Person extends CActiveRecord implements IRISItem
     public function getName($kurzfassung = false)
     {
         if ($kurzfassung) {
-            if (in_array($this->id, array(279))) return "Freiheitsrechte Transparenz Bürgerbeteiligung";
+            if (in_array($this->id, [279])) return "Freiheitsrechte Transparenz Bürgerbeteiligung";
         }
         return $this->name;
     }

--- a/protected/models/RISAenderung.php
+++ b/protected/models/RISAenderung.php
@@ -32,7 +32,7 @@ class RISAenderung extends CActiveRecord
     public static $TYP_RATHAUSUMSCHAU = "rathausumschau";
     public static $TYP_BA_MITGLIED = "ba_mitglied";
     public static $TYP_BA_ERGEBNIS = "ba_ergebnis";
-    public static $TYPEN_ALLE = array(
+    public static $TYPEN_ALLE = [
         "stadtrat_antrag"   => "stadtratsantrag",
         "stadtrat_vorlage"  => "Stadtratsvorlage",
         "stadtrat_termin"   => "Stadtratstermin",
@@ -47,7 +47,7 @@ class RISAenderung extends CActiveRecord
         "ba_mitglied"       => "BA-Mitglied",
         "ba_ergebnis"       => "BA-Tagesordnung",
         "rathausumschau"    => "Rathausumschau",
-    );
+    ];
 
     /**
      * Returns the static model of the specified AR class.
@@ -74,11 +74,11 @@ class RISAenderung extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('ris_id, typ, datum, aenderungen', 'required'),
-            array('ris_id, ba_nr', 'numerical', 'integerOnly' => true),
-            array('typ', 'length', 'max' => 20),
-        );
+        return [
+            ['ris_id, typ, datum, aenderungen', 'required'],
+            ['ris_id, ba_nr', 'numerical', 'integerOnly' => true],
+            ['typ', 'length', 'max' => 20],
+        ];
     }
 
     /**
@@ -88,9 +88,9 @@ class RISAenderung extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'baNr' => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-        );
+        return [
+            'baNr' => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+        ];
     }
 
     /**
@@ -98,14 +98,14 @@ class RISAenderung extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'          => 'ID',
             'ris_id'      => 'Ris',
             'ba_nr'       => 'Ba Nr',
             'typ'         => 'Typ',
             'datum'       => 'Datum',
             'aenderungen' => 'Aenderungen',
-        );
+        ];
     }
 
     /**
@@ -149,12 +149,12 @@ class RISAenderung extends CActiveRecord
     public function toFeedData()
     {
         $item = $this->getRISItem();
-        return array(
+        return [
             "title"          => ($item ? $item->getTypName() . ": " . $item->getName() : "?"),
             "link"           => ($item ? $item->getLink() : "-"),
             "content"        => nl2br(CHtml::encode($this->aenderungen)),
             "dateCreated"    => RISTools::date_iso2timestamp($this->datum),
-            "aenderung_guid" => Yii::app()->createUrl("aenderung/anzeigen", array("id" => $this->id))
-        );
+            "aenderung_guid" => Yii::app()->createUrl("aenderung/anzeigen", ["id" => $this->id])
+        ];
     }
 }

--- a/protected/models/RISMetadaten.php
+++ b/protected/models/RISMetadaten.php
@@ -27,7 +27,7 @@ class RISMetadaten
     public static function getStats()
     {
         $result = Yii::app()->db->createCommand("SELECT * FROM metadaten WHERE meta_key IN ('anzahl_dokumente', 'anzahl_dokumente_1w', 'anzahl_seiten', 'anzahl_seiten_1w', 'letzte_aktualisierung')")->queryAll();
-        $ret    = array();
+        $ret    = [];
         foreach ($result as $res) $ret[$res["meta_key"]] = $res["meta_val"];
         return $ret;
     }

--- a/protected/models/Rathausumschau.php
+++ b/protected/models/Rathausumschau.php
@@ -36,12 +36,12 @@ class Rathausumschau extends CActiveRecord implements IRISItem
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('url, datum, jahr, nr', 'required'),
-            array('id, jahr, nr', 'numerical', 'integerOnly' => true),
-            array('url', 'length', 'max' => 200),
-            array('datum', 'length', 'max' => 10),
-        );
+        return [
+            ['url, datum, jahr, nr', 'required'],
+            ['id, jahr, nr', 'numerical', 'integerOnly' => true],
+            ['url', 'length', 'max' => 200],
+            ['datum', 'length', 'max' => 10],
+        ];
     }
 
     /**
@@ -49,9 +49,9 @@ class Rathausumschau extends CActiveRecord implements IRISItem
      */
     public function relations()
     {
-        return array(
-            'dokumente' => array(self::HAS_MANY, 'Dokument', 'rathausumschau_id'),
-        );
+        return [
+            'dokumente' => [self::HAS_MANY, 'Dokument', 'rathausumschau_id'],
+        ];
     }
 
     /**
@@ -59,20 +59,20 @@ class Rathausumschau extends CActiveRecord implements IRISItem
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'    => 'ID',
             'datum' => 'Datum',
             'url'   => 'URL',
             'jahr'  => 'Jahr',
             'nr'    => 'Nr.',
-        );
+        ];
     }
 
     /**
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
         if (count($this->dokumente) > 0) {
             return $this->dokumente[0]->getLink();
@@ -108,14 +108,14 @@ class Rathausumschau extends CActiveRecord implements IRISItem
      */
     public function inhaltsverzeichnis()
     {
-        if (count($this->dokumente) == 0) return array();
+        if (count($this->dokumente) == 0) return [];
         $dok = $this->dokumente[0]->text_pdf;
         $x   = explode("Inhaltsverzeichnis", $dok);
-        if (count($x) == 1) return array();
+        if (count($x) == 1) return [];
 
         $x        = explode("Antworten auf Stadtratsanfragen", $x[1]);
         $text     = $x[0];
-        $tops_out = array();
+        $tops_out = [];
         $link     = $this->dokumente[0]->getLinkZumDokument();
 
         $tops_in = explode("›", $text);
@@ -123,8 +123,8 @@ class Rathausumschau extends CActiveRecord implements IRISItem
         for ($i = 1; $i < count($tops_in); $i++) {
             $top = trim(str_replace("\n", " ", $tops_in[$i]));
             preg_match("/^(?<titel>.*)(?<seite> [0-9]+)$/siu", $top, $matches);
-            if (isset($matches["seite"])) $tops_out[] = array("titel" => $matches["titel"], "seite" => IntVal($matches["seite"]), "link" => $link . "#page=" . IntVal($matches["seite"]));
-            elseif (isset($matches["titel"])) $tops_out[] = array("titel" => $matches["titel"], "seite" => null, "link" => null);
+            if (isset($matches["seite"])) $tops_out[] = ["titel" => $matches["titel"], "seite" => IntVal($matches["seite"]), "link" => $link . "#page=" . IntVal($matches["seite"])];
+            elseif (isset($matches["titel"])) $tops_out[] = ["titel" => $matches["titel"], "seite" => null, "link" => null];
         }
         return $tops_out;
     }

--- a/protected/models/Rechtsdokument.php
+++ b/protected/models/Rechtsdokument.php
@@ -39,12 +39,12 @@ class Rechtsdokument extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id', 'length', 'max' => 200),
-            array('titel', 'length', 'max' => 200),
-            array('url_base, url_html, url_pdf', 'length', 'max' => 200),
-            array('str_beschluss, bekanntmachung', 'length', 'max' => 10),
-        );
+        return [
+            ['id', 'length', 'max' => 200],
+            ['titel', 'length', 'max' => 200],
+            ['url_base, url_html, url_pdf', 'length', 'max' => 200],
+            ['str_beschluss, bekanntmachung', 'length', 'max' => 10],
+        ];
     }
 
     /**
@@ -52,7 +52,7 @@ class Rechtsdokument extends CActiveRecord
      */
     public function relations()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -60,7 +60,7 @@ class Rechtsdokument extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'             => 'id',
             'titel'          => 'titel',
             'url_base'       => 'url-base',
@@ -70,7 +70,7 @@ class Rechtsdokument extends CActiveRecord
             'bekanntmachung' => 'Bekanntmachung',
             'html'           => 'HTML',
             'css'            => 'CSS'
-        );
+        ];
     }
 
     public function alle_sortiert()

--- a/protected/models/Referat.php
+++ b/protected/models/Referat.php
@@ -45,15 +45,15 @@ class Referat extends CActiveRecord implements IRISItem
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, name, urlpart', 'required'),
-            array('id, aktiv', 'numerical', 'integerOnly' => true),
-            array('name, email, telefon', 'length', 'max' => 100),
-            array('kurzbeschreibung, website', 'length', 'max' => 200),
-            array('strasse, urlpart', 'length', 'max' => 45),
-            array('plz', 'length', 'max' => 10),
-            array('ort', 'length', 'max' => 30),
-        );
+        return [
+            ['id, name, urlpart', 'required'],
+            ['id, aktiv', 'numerical', 'integerOnly' => true],
+            ['name, email, telefon', 'length', 'max' => 100],
+            ['kurzbeschreibung, website', 'length', 'max' => 200],
+            ['strasse, urlpart', 'length', 'max' => 45],
+            ['plz', 'length', 'max' => 10],
+            ['ort', 'length', 'max' => 30],
+        ];
     }
 
     /**
@@ -63,10 +63,10 @@ class Referat extends CActiveRecord implements IRISItem
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'antraege'               => array(self::HAS_MANY, 'Antrag', 'referat_id'),
-            'stadtraetInnenReferate' => array(self::HAS_MANY, 'StadtraetInReferat', 'referat_id'),
-        );
+        return [
+            'antraege'               => [self::HAS_MANY, 'Antrag', 'referat_id'],
+            'stadtraetInnenReferate' => [self::HAS_MANY, 'StadtraetInReferat', 'referat_id'],
+        ];
     }
 
     /**
@@ -74,7 +74,7 @@ class Referat extends CActiveRecord implements IRISItem
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'               => 'ID',
             'name'             => 'Name',
             'urlpart'          => 'URL',
@@ -86,16 +86,16 @@ class Referat extends CActiveRecord implements IRISItem
             'website'          => 'Website',
             'kurzbeschreibung' => 'Kurzbeschreibung',
             'aktiv'            => 'Aktiv',
-        );
+        ];
     }
 
     /**
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
-        return Yii::app()->createUrl("themen/referat", array_merge(array("id" => $this->id), $add_params));
+        return Yii::app()->createUrl("themen/referat", array_merge(["id" => $this->id], $add_params));
     }
 
 
@@ -130,7 +130,7 @@ class Referat extends CActiveRecord implements IRISItem
     public static function getByHtmlName($name)
     {
         $name = trim(strip_tags($name));
-        $ref  = Referat::model()->findByAttributes(array("name" => $name));
+        $ref  = Referat::model()->findByAttributes(["name" => $name]);
         return $ref;
     }
 
@@ -149,19 +149,19 @@ class Referat extends CActiveRecord implements IRISItem
         if ($zeit_von != "" && $zeit_bis != "") $time_condition .= ' AND ';
         if ($zeit_bis != "") $time_condition .= 'c.datum <= "' . addslashes($zeit_bis) . '"';
 
-        $params = array(
+        $params = [
             'alias'     => 'a',
             'condition' => 'a.id = ' . IntVal($referat_id),
             'order'     => 'c.datum DESC',
-            'with'      => array(
-                'antraege'           => array(
+            'with'      => [
+                'antraege'           => [
                     'alias' => 'b',
-                ),
-                'antraege.dokumente' => array(
+                ],
+                'antraege.dokumente' => [
                     'alias'     => 'c',
                     'condition' => $time_condition,
-                ),
-            ));
+                ],
+            ]];
         if ($limit > 0) $params['limit'] = $limit;
         $this->getDbCriteria()->mergeWith($params);
         return $this;

--- a/protected/models/StadtraetIn.php
+++ b/protected/models/StadtraetIn.php
@@ -29,11 +29,11 @@
  */
 class StadtraetIn extends CActiveRecord implements IRISItem
 {
-    public static $GESCHLECHTER = array(
+    public static $GESCHLECHTER = [
         "weiblich"  => "Weiblich",
         "maennlich" => "Männlich",
         "sonstiges" => "Beides passt nicht",
-    );
+    ];
 
 
     /**
@@ -59,14 +59,14 @@ class StadtraetIn extends CActiveRecord implements IRISItem
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, name, referentIn', 'required'),
-            array('id, referentIn, benutzerIn_id', 'numerical', 'integerOnly' => true),
-            array('web', 'length', 'max' => 250),
-            array('name, email', 'length', 'max' => 100),
-            array('twitter', 'length', 'max' => 45),
-            array('facebook, abgeordnetenwatch', 'length', 'max' => 200),
-        );
+        return [
+            ['id, name, referentIn', 'required'],
+            ['id, referentIn, benutzerIn_id', 'numerical', 'integerOnly' => true],
+            ['web', 'length', 'max' => 250],
+            ['name, email', 'length', 'max' => 100],
+            ['twitter', 'length', 'max' => 45],
+            ['facebook, abgeordnetenwatch', 'length', 'max' => 200],
+        ];
     }
 
     /**
@@ -76,14 +76,14 @@ class StadtraetIn extends CActiveRecord implements IRISItem
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'antraege'                 => array(self::MANY_MANY, 'Antrag', 'antraege_stadtraetInnen(stadtraetIn_id, antrag_id)', 'order' => 'gestellt_am DESC'),
-            'personen'                 => array(self::HAS_MANY, 'Person', 'ris_stadtraetIn'),
-            'stadtraetInnenFraktionen' => array(self::HAS_MANY, 'StadtraetInFraktion', 'stadtraetIn_id', 'order' => 'wahlperiode DESC'),
-            'mitgliedschaften'         => array(self::HAS_MANY, 'StadtraetInGremium', 'stadtraetIn_id'),
-            'stadtraetInnenReferate'   => array(self::HAS_MANY, 'StadtraetInReferat', 'stadtraetIn_id'),
-            'benutzerIn'               => array(self::HAS_ONE, 'BenutzerIn', 'benutzerIn_id'),
-        );
+        return [
+            'antraege'                 => [self::MANY_MANY, 'Antrag', 'antraege_stadtraetInnen(stadtraetIn_id, antrag_id)', 'order' => 'gestellt_am DESC'],
+            'personen'                 => [self::HAS_MANY, 'Person', 'ris_stadtraetIn'],
+            'stadtraetInnenFraktionen' => [self::HAS_MANY, 'StadtraetInFraktion', 'stadtraetIn_id', 'order' => 'wahlperiode DESC'],
+            'mitgliedschaften'         => [self::HAS_MANY, 'StadtraetInGremium', 'stadtraetIn_id'],
+            'stadtraetInnenReferate'   => [self::HAS_MANY, 'StadtraetInReferat', 'stadtraetIn_id'],
+            'benutzerIn'               => [self::HAS_ONE, 'BenutzerIn', 'benutzerIn_id'],
+        ];
     }
 
     /**
@@ -91,7 +91,7 @@ class StadtraetIn extends CActiveRecord implements IRISItem
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                => 'ID',
             'benutzerIn_id'     => 'BenutzerIn-ID',
             'gewaehlt_am'       => 'Gewaehlt Am',
@@ -107,17 +107,17 @@ class StadtraetIn extends CActiveRecord implements IRISItem
             'beruf'             => 'Beruf',
             'beschreibung'      => 'Beschreibung',
             'quellen'           => 'Quellen',
-        );
+        ];
     }
 
     /**
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
         $name = $this->getName();
-        return Yii::app()->createUrl("personen/person", array_merge(array("id" => $this->id, "name" => $name), $add_params));
+        return Yii::app()->createUrl("personen/person", array_merge(["id" => $this->id, "name" => $name], $add_params));
     }
 
 
@@ -213,8 +213,8 @@ class StadtraetIn extends CActiveRecord implements IRISItem
     {
         $name1 = preg_replace("/^([a-z]+\. )*/siu", "", $name1);
         $name2 = preg_replace("/^([a-z]+\. )*/siu", "", $name2);
-        $name1 = str_replace(array("Ä", "Ö", "Ü", "ä", "ö", "ü", "ß"), array("A", "O", "U", "a", "o", "u", "s"), $name1);
-        $name2 = str_replace(array("Ä", "Ö", "Ü", "ä", "Ö", "ü", "ß"), array("A", "O", "U", "a", "o", "u", "s"), $name2);
+        $name1 = str_replace(["Ä", "Ö", "Ü", "ä", "ö", "ü", "ß"], ["A", "O", "U", "a", "o", "u", "s"], $name1);
+        $name2 = str_replace(["Ä", "Ö", "Ü", "ä", "Ö", "ü", "ß"], ["A", "O", "U", "a", "o", "u", "s"], $name2);
         return strnatcasecmp($name1, $name2);
     }
 
@@ -268,11 +268,11 @@ class StadtraetIn extends CActiveRecord implements IRISItem
                 $mitgliedschaft->datum_von       = $override["datum_von"];
                 $mitgliedschaft->datum_bis       = $override["datum_bis"];
                 $mitgliedschaft->wahlperiode     = $override["wahlperiode"];
-                $this->stadtraetInnenFraktionen = array_merge(array($mitgliedschaft), $this->stadtraetInnenFraktionen);
+                $this->stadtraetInnenFraktionen = array_merge([$mitgliedschaft], $this->stadtraetInnenFraktionen);
             }
         }
         if (isset(StadtraetInFraktionOverrides::$FRAKTION_DEL[$this->id])) {
-            $fraktionen_neu = array();
+            $fraktionen_neu = [];
             foreach ($this->stadtraetInnenFraktionen as $mitgliedschaft) {
                 $todel = false;
                 foreach (StadtraetInFraktionOverrides::$FRAKTION_DEL[$this->id] as $override) {
@@ -302,24 +302,24 @@ class StadtraetIn extends CActiveRecord implements IRISItem
         }
 
         /** @var StadtraetIn[] $strs_in */
-        $strs_in = StadtraetIn::model()->findAll(array(
+        $strs_in = StadtraetIn::model()->findAll([
             'alias' => 'a',
             'order' => 'a.name ASC',
-            'with'  => array(
-                'stadtraetInnenFraktionen'          => array(
+            'with'  => [
+                'stadtraetInnenFraktionen'          => [
                     'alias'     => 'b',
                     'condition' => 'b.datum_von <= "' . addslashes($datum) . '" AND (b.datum_bis IS NULL OR b.datum_bis >= "' . addslashes($datum) . '")',
-                ),
-                'stadtraetInnenFraktionen.fraktion' => array(
+                ],
+                'stadtraetInnenFraktionen.fraktion' => [
                     'alias'     => 'c',
                     'condition' => $ba_where,
-                )
-            )));
+                ]
+            ]]);
 
         foreach ($strs_in as $key => $strIn) $strIn->overrideFraktionsMitgliedschaften();
 
         /** @var StadtraetIn[] $strs_out */
-        $strs_out = array();
+        $strs_out = [];
         foreach ($strs_in as $strs) {
             if ($strs->id == 3425214) {
                 continue;
@@ -337,13 +337,13 @@ class StadtraetIn extends CActiveRecord implements IRISItem
     public static function getGroupedByFraktion($datum, $ba_nr)
     {
         $strs       = static::getByFraktion($datum, $ba_nr);
-        $fraktionen = array();
+        $fraktionen = [];
         foreach ($strs as $str) {
             if (count($str->stadtraetInnenFraktionen) == 0) {
                 continue;
             }
             if (!isset($fraktionen[$str->stadtraetInnenFraktionen[0]->fraktion_id])) {
-                $fraktionen[$str->stadtraetInnenFraktionen[0]->fraktion_id] = array();
+                $fraktionen[$str->stadtraetInnenFraktionen[0]->fraktion_id] = [];
             }
             $fraktionen[$str->stadtraetInnenFraktionen[0]->fraktion_id][] = $str;
         }

--- a/protected/models/StadtraetInFraktion.php
+++ b/protected/models/StadtraetInFraktion.php
@@ -40,13 +40,13 @@ class StadtraetInFraktion extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('stadtraetIn_id, fraktion_id, wahlperiode, mitgliedschaft, datum_von', 'required'),
-            array('stadtraetIn_id, fraktion_id', 'numerical', 'integerOnly' => true),
-            array('wahlperiode', 'length', 'max' => 30),
-            array('datum_von, datum_bis', 'length', 'max' => 10),
-            array('funktion', 'safe'),
-        );
+        return [
+            ['stadtraetIn_id, fraktion_id, wahlperiode, mitgliedschaft, datum_von', 'required'],
+            ['stadtraetIn_id, fraktion_id', 'numerical', 'integerOnly' => true],
+            ['wahlperiode', 'length', 'max' => 30],
+            ['datum_von, datum_bis', 'length', 'max' => 10],
+            ['funktion', 'safe'],
+        ];
     }
 
     /**
@@ -56,10 +56,10 @@ class StadtraetInFraktion extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'fraktion'    => array(self::BELONGS_TO, 'Fraktion', 'fraktion_id'),
-            'stadtraetIn' => array(self::BELONGS_TO, 'StadtraetIn', 'stadtraetIn_id'),
-        );
+        return [
+            'fraktion'    => [self::BELONGS_TO, 'Fraktion', 'fraktion_id'],
+            'stadtraetIn' => [self::BELONGS_TO, 'StadtraetIn', 'stadtraetIn_id'],
+        ];
     }
 
     /**
@@ -67,7 +67,7 @@ class StadtraetInFraktion extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'stadtraetIn_id' => 'StadträtIn',
             'fraktion_id'    => 'Fraktion',
             'wahlperiode'    => 'Wahlperiode',
@@ -75,7 +75,7 @@ class StadtraetInFraktion extends CActiveRecord
             'funktion'       => 'Funktion',
             'datum_von'      => 'Von',
             'datum_bis'      => 'Bis',
-        );
+        ];
     }
 
     /**

--- a/protected/models/StadtraetInGremium.php
+++ b/protected/models/StadtraetInGremium.php
@@ -38,12 +38,12 @@ class StadtraetInGremium extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('stadtraetIn_id, gremium_id, datum_von', 'required'),
-            array('stadtraetIn_id, gremium_id', 'numerical', 'integerOnly' => true),
-            array('datum_von, datum_bis', 'length', 'max' => 10),
-            array('funktion, datum_von, datum_bis', 'safe'),
-        );
+        return [
+            ['stadtraetIn_id, gremium_id, datum_von', 'required'],
+            ['stadtraetIn_id, gremium_id', 'numerical', 'integerOnly' => true],
+            ['datum_von, datum_bis', 'length', 'max' => 10],
+            ['funktion, datum_von, datum_bis', 'safe'],
+        ];
     }
 
     /**
@@ -53,10 +53,10 @@ class StadtraetInGremium extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'gremium'     => array(self::BELONGS_TO, 'Gremium', 'gremium_id'),
-            'stadtraetIn' => array(self::BELONGS_TO, 'StadtraetIn', 'stadtraetIn_id'),
-        );
+        return [
+            'gremium'     => [self::BELONGS_TO, 'Gremium', 'gremium_id'],
+            'stadtraetIn' => [self::BELONGS_TO, 'StadtraetIn', 'stadtraetIn_id'],
+        ];
     }
 
     /**
@@ -64,13 +64,13 @@ class StadtraetInGremium extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'stadtraetIn_id' => 'StadträtIn',
             'gremium_id'     => 'Gremium',
             'funktion'       => 'Funktion',
             'datum_von'      => 'Von',
             'datum_bis'      => 'Bis',
-        );
+        ];
     }
 
     /**

--- a/protected/models/StadtraetInReferat.php
+++ b/protected/models/StadtraetInReferat.php
@@ -38,12 +38,12 @@ class StadtraetInReferat extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('stadtraetIn_id, referat_id', 'required'),
-            array('stadtraetIn_id, referat_id, id', 'numerical', 'integerOnly' => true),
-            array('datum_von, datum_bis', 'length', 'max' => 10),
-            array('datum_von, datum_bis', 'safe'),
-        );
+        return [
+            ['stadtraetIn_id, referat_id', 'required'],
+            ['stadtraetIn_id, referat_id, id', 'numerical', 'integerOnly' => true],
+            ['datum_von, datum_bis', 'length', 'max' => 10],
+            ['datum_von, datum_bis', 'safe'],
+        ];
     }
 
     /**
@@ -53,10 +53,10 @@ class StadtraetInReferat extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'referat'     => array(self::BELONGS_TO, 'Referat', 'referat_id'),
-            'stadtraetIn' => array(self::BELONGS_TO, 'StadtraetIn', 'stadtraetIn_id'),
-        );
+        return [
+            'referat'     => [self::BELONGS_TO, 'Referat', 'referat_id'],
+            'stadtraetIn' => [self::BELONGS_TO, 'StadtraetIn', 'stadtraetIn_id'],
+        ];
     }
 
     /**
@@ -64,12 +64,12 @@ class StadtraetInReferat extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'             => 'id',
             'stadtraetIn_id' => 'StadträtIn',
             'referat_id'     => 'Referat',
             'datum_von'      => 'Von',
             'datum_bis'      => 'Bis',
-        );
+        ];
     }
 }

--- a/protected/models/StatistikDatensatz.php
+++ b/protected/models/StatistikDatensatz.php
@@ -51,9 +51,9 @@ class StatistikDatensatz extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('quelle', 'required'),
-        );
+        return [
+            ['quelle', 'required'],
+        ];
     }
 
     /**
@@ -63,7 +63,7 @@ class StatistikDatensatz extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array();
+        return [];
     }
 
     /**
@@ -71,8 +71,8 @@ class StatistikDatensatz extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'      => 'ID',
-        );
+        ];
     }
 }

--- a/protected/models/Strasse.php
+++ b/protected/models/Strasse.php
@@ -40,11 +40,11 @@ class Strasse extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('name', 'required'),
-            array('name', 'length', 'max' => 100),
-            array('plz', 'length', 'max' => 20),
-        );
+        return [
+            ['name', 'required'],
+            ['name', 'length', 'max' => 100],
+            ['plz', 'length', 'max' => 20],
+        ];
     }
 
     /**
@@ -54,7 +54,7 @@ class Strasse extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array();
+        return [];
     }
 
     /**
@@ -62,11 +62,11 @@ class Strasse extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'      => 'ID',
             'name'    => 'Name',
             'plz'     => 'Plz',
             'osm_ref' => 'Osm Ref',
-        );
+        ];
     }
 }

--- a/protected/models/Tag.php
+++ b/protected/models/Tag.php
@@ -42,12 +42,12 @@ class Tag extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('name', 'required'),
-            array('id, angelegt_benutzerIn_id, reviewed', 'numerical', 'integerOnly' => true),
-            array('name', 'length', 'max' => 100),
-            array('angelegt_datum', 'length', 'max' => 20),
-        );
+        return [
+            ['name', 'required'],
+            ['id, angelegt_benutzerIn_id, reviewed', 'numerical', 'integerOnly' => true],
+            ['name', 'length', 'max' => 100],
+            ['angelegt_datum', 'length', 'max' => 20],
+        ];
     }
 
     /**
@@ -55,10 +55,10 @@ class Tag extends CActiveRecord
      */
     public function relations()
     {
-        return array(
-            'angelegt_benutzerIn' => array(self::BELONGS_TO, 'BenutzerIn', 'angelegt_benutzerIn_id'),
-            'antraege'            => array(self::MANY_MANY, 'Antrag', 'antraege_tags(tag_id, antrag_id)'),
-        );
+        return [
+            'angelegt_benutzerIn' => [self::BELONGS_TO, 'BenutzerIn', 'angelegt_benutzerIn_id'],
+            'antraege'            => [self::MANY_MANY, 'Antrag', 'antraege_tags(tag_id, antrag_id)'],
+        ];
     }
 
     /**
@@ -66,7 +66,7 @@ class Tag extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                     => 'ID',
             'name'                   => 'Name',
             'reviewed'               => 'Geprüft',
@@ -74,7 +74,7 @@ class Tag extends CActiveRecord
             'angelegt_benutzerIn_id' => 'Anegelegt: BenutzerIn-ID',
             'angelegt_benutzerIn'    => 'Anegelegt: BenutzerIn',
             'antraege'               => 'Anträge',
-        );
+        ];
     }
 
     /**
@@ -83,7 +83,7 @@ class Tag extends CActiveRecord
     public function getNameLink()
     {
         $link_name = $this->name;
-        return CHtml::link($this->name, Yii::app()->createUrl("themen/tag", array("tag_id" => $this->id, "tag_name" => $link_name)));
+        return CHtml::link($this->name, Yii::app()->createUrl("themen/tag", ["tag_id" => $this->id, "tag_name" => $link_name]));
     }
 
     /**
@@ -96,7 +96,7 @@ class Tag extends CActiveRecord
 
         /** @var Tag[] $tags */
         $tags     = Tag::model()->findAll();
-        $tags_out = array();
+        $tags_out = [];
         foreach ($tags as $tag) if (count($tag->antraege) > 0) $tags_out[] = $tag;
         return $tags_out;
     }

--- a/protected/models/Tagesordnungspunkt.php
+++ b/protected/models/Tagesordnungspunkt.php
@@ -52,12 +52,12 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('top_betreff, sitzungstermin_id, sitzungstermin_datum, datum_letzte_aenderung', 'required'),
-            array('antrag_id, gremium_id, sitzungstermin_id, top_ueberschrift, vorgang_id', 'numerical', 'integerOnly' => true),
-            array('gremium_name', 'length', 'max' => 100),
-            array('beschluss_text', 'length', 'max' => 500),
-        );
+        return [
+            ['top_betreff, sitzungstermin_id, sitzungstermin_datum, datum_letzte_aenderung', 'required'],
+            ['antrag_id, gremium_id, sitzungstermin_id, top_ueberschrift, vorgang_id', 'numerical', 'integerOnly' => true],
+            ['gremium_name', 'length', 'max' => 100],
+            ['beschluss_text', 'length', 'max' => 500],
+        ];
     }
 
     /**
@@ -67,13 +67,13 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'sitzungstermin' => array(self::BELONGS_TO, 'Termin', 'sitzungstermin_id'),
-            'gremium'        => array(self::BELONGS_TO, 'Gremium', 'gremium_id'),
-            'antrag'         => array(self::BELONGS_TO, 'Antrag', 'antrag_id'),
-            'dokumente'      => array(self::HAS_MANY, 'Dokument', 'tagesordnungspunkt_id'),
-            'vorgang'        => array(self::BELONGS_TO, 'Vorgang', 'vorgang_id'),
-        );
+        return [
+            'sitzungstermin' => [self::BELONGS_TO, 'Termin', 'sitzungstermin_id'],
+            'gremium'        => [self::BELONGS_TO, 'Gremium', 'gremium_id'],
+            'antrag'         => [self::BELONGS_TO, 'Antrag', 'antrag_id'],
+            'dokumente'      => [self::HAS_MANY, 'Dokument', 'tagesordnungspunkt_id'],
+            'vorgang'        => [self::BELONGS_TO, 'Vorgang', 'vorgang_id'],
+        ];
     }
 
     /**
@@ -81,7 +81,7 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                     => 'ID',
             'vorgang_id'             => 'Vorgangs-ID',
             'antrag_id'              => 'Antrag',
@@ -96,7 +96,7 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
             'top_ueberschrift'       => 'Ist Überschrift',
             'top_betreff'            => 'Betreff',
             'status'                 => 'Status'
-        );
+        ];
     }
 
     /**
@@ -122,9 +122,9 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
      */
     public function get_geo()
     {
-        $return            = array();
+        $return            = [];
         $strassen_gefunden = RISGeo::suche_strassen($this->top_betreff);
-        $indexed           = array();
+        $indexed           = [];
         foreach ($strassen_gefunden as $strasse_name) if (!in_array($strasse_name, $indexed)) {
             $indexed[] = $strasse_name;
             $geo       = OrtGeo::getOrCreate($strasse_name);
@@ -139,13 +139,13 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
      */
     public function zugeordneteAntraegeHeuristisch()
     {
-        $betreff = str_replace(array("\n", "\r"), array(" ", " "), $this->top_betreff);
+        $betreff = str_replace(["\n", "\r"], [" ", " "], $this->top_betreff);
         preg_match_all("/[0-9]{2}\-[0-9]{2} ?\/ ?[A-Z] ?[0-9]+/su", $betreff, $matches);
 
-        $antraege = array();
+        $antraege = [];
         foreach ($matches[0] as $match) {
             /** @var Antrag $antrag */
-            $antrag = Antrag::model()->findByAttributes(array("antrags_nr" => Antrag::cleanAntragNr($match)));
+            $antrag = Antrag::model()->findByAttributes(["antrags_nr" => Antrag::cleanAntragNr($match)]);
             if ($antrag) $antraege[] = $antrag;
             else $antraege[] = "Nr. " . $match;
         }
@@ -157,7 +157,7 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
         if ($this->antrag) return $this->antrag->getLink($add_params);
         return $this->sitzungstermin->getLink($add_params);
@@ -177,7 +177,7 @@ class Tagesordnungspunkt extends CActiveRecord implements IRISItemHasDocuments
     public function getName($kurzfassung = false)
     {
         if ($kurzfassung) {
-            $betreff = str_replace(array("\n", "\r"), array(" ", " "), $this->top_betreff);
+            $betreff = str_replace(["\n", "\r"], [" ", " "], $this->top_betreff);
             $x       = explode(" Antrag Nr.", $betreff);
             $x       = explode("<strong>Antrag: </strong>", $x[0]);
             return RISTools::korrigiereTitelZeichen($x[0]);

--- a/protected/models/TagesordnungspunktHistory.php
+++ b/protected/models/TagesordnungspunktHistory.php
@@ -52,12 +52,12 @@ class TagesordnungspunktHistory extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('top_betreff, sitzungstermin_id, sitzungstermin_datum, datum_letzte_aenderung', 'required'),
-            array('antrag_id, gremium_id, sitzungstermin_id, top_ueberschrift, vorgang_id', 'numerical', 'integerOnly' => true),
-            array('gremium_name', 'length', 'max' => 100),
-            array('beschluss_text', 'length', 'max' => 500),
-        );
+        return [
+            ['top_betreff, sitzungstermin_id, sitzungstermin_datum, datum_letzte_aenderung', 'required'],
+            ['antrag_id, gremium_id, sitzungstermin_id, top_ueberschrift, vorgang_id', 'numerical', 'integerOnly' => true],
+            ['gremium_name', 'length', 'max' => 100],
+            ['beschluss_text', 'length', 'max' => 500],
+        ];
     }
 
     /**
@@ -67,13 +67,13 @@ class TagesordnungspunktHistory extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'sitzungstermin' => array(self::BELONGS_TO, 'Termin', 'sitzungstermin_id'),
-            'gremium'        => array(self::BELONGS_TO, 'Gremium', 'gremium_id'),
-            'antrag'         => array(self::BELONGS_TO, 'Antrag', 'antrag_id'),
-            'dokumente'      => array(self::HAS_MANY, 'Dokument', 'tagesordnungspunkt_id'),
-            'vorgang'        => array(self::BELONGS_TO, 'Vorgang', 'vorgang_id'),
-        );
+        return [
+            'sitzungstermin' => [self::BELONGS_TO, 'Termin', 'sitzungstermin_id'],
+            'gremium'        => [self::BELONGS_TO, 'Gremium', 'gremium_id'],
+            'antrag'         => [self::BELONGS_TO, 'Antrag', 'antrag_id'],
+            'dokumente'      => [self::HAS_MANY, 'Dokument', 'tagesordnungspunkt_id'],
+            'vorgang'        => [self::BELONGS_TO, 'Vorgang', 'vorgang_id'],
+        ];
     }
 
     /**
@@ -81,7 +81,7 @@ class TagesordnungspunktHistory extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                     => 'ID',
             'vorgang_id'             => 'Vorgangs-ID',
             'antrag_id'              => 'Antrag',
@@ -96,7 +96,7 @@ class TagesordnungspunktHistory extends CActiveRecord
             'top_ueberschrift'       => 'Ist Überschrift',
             'top_betreff'            => 'Betreff',
             'status'                 => 'Status'
-        );
+        ];
     }
 
     /**
@@ -106,7 +106,7 @@ class TagesordnungspunktHistory extends CActiveRecord
     public function getName($kurzfassung = false)
     {
         if ($kurzfassung) {
-            $betreff = str_replace(array("\n", "\r"), array(" ", " "), $this->top_betreff);
+            $betreff = str_replace(["\n", "\r"], [" ", " "], $this->top_betreff);
             $x       = explode(" Antrag Nr.", $betreff);
             return RISTools::korrigiereTitelZeichen($x[0]);
         } else {

--- a/protected/models/Termin.php
+++ b/protected/models/Termin.php
@@ -32,10 +32,10 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
 {
     public static $TYP_AUTO   = 0;
     public static $TYP_BV     = 1;
-    public static $TYPEN_ALLE = array(
+    public static $TYPEN_ALLE = [
         0 => "Automatisch vom RIS",
         1 => "BürgerInnenversammlung",
-    );
+    ];
 
 
     /**
@@ -63,14 +63,14 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, typ, datum_letzte_aenderung', 'required'),
-            array('id, typ, termin_reihe, gremium_id, ba_nr, termin_prev_id, termin_next_id', 'numerical', 'integerOnly' => true),
-            array('referat, referent, vorsitz', 'length', 'max' => 200),
-            array('wahlperiode', 'length', 'max' => 20),
-            array('status, sitzungsstand', 'length', 'max' => 100),
-            array('termin_reihe, gremium_id, ba_nr, termin, termin_prev_id, termin_next_id, sitzungsort, referat, referent, vorsitz, wahlperiode, sitzungsstand', 'safe'),
-        );
+        return [
+            ['id, typ, datum_letzte_aenderung', 'required'],
+            ['id, typ, termin_reihe, gremium_id, ba_nr, termin_prev_id, termin_next_id', 'numerical', 'integerOnly' => true],
+            ['referat, referent, vorsitz', 'length', 'max' => 200],
+            ['wahlperiode', 'length', 'max' => 20],
+            ['status, sitzungsstand', 'length', 'max' => 100],
+            ['termin_reihe, gremium_id, ba_nr, termin, termin_prev_id, termin_next_id, sitzungsort, referat, referent, vorsitz, wahlperiode, sitzungsstand', 'safe'],
+        ];
     }
 
     /**
@@ -80,13 +80,13 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'antraegeDokumente'   => array(self::HAS_MANY, 'Dokument', 'termin_id'),
-            'tagesordnungspunkte' => array(self::HAS_MANY, 'Tagesordnungspunkt', 'sitzungstermin_id'),
-            'antraegeOrte'        => array(self::HAS_MANY, 'AntragOrt', 'termin_id'),
-            'gremium'             => array(self::BELONGS_TO, 'Gremium', 'gremium_id'),
-            'ba'                  => array(self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'),
-        );
+        return [
+            'antraegeDokumente'   => [self::HAS_MANY, 'Dokument', 'termin_id'],
+            'tagesordnungspunkte' => [self::HAS_MANY, 'Tagesordnungspunkt', 'sitzungstermin_id'],
+            'antraegeOrte'        => [self::HAS_MANY, 'AntragOrt', 'termin_id'],
+            'gremium'             => [self::BELONGS_TO, 'Gremium', 'gremium_id'],
+            'ba'                  => [self::BELONGS_TO, 'Bezirksausschuss', 'ba_nr'],
+        ];
     }
 
     /**
@@ -94,7 +94,7 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                     => 'ID',
             'typ'                    => 'Typ',
             'datum_letzte_aenderung' => 'Datum Letzte Aenderung',
@@ -111,7 +111,7 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
             'wahlperiode'            => 'Wahlperiode',
             'status'                 => 'Status',
             'sitzungsstand'          => 'Sitzungsstand',
-        );
+        ];
     }
 
     /**
@@ -139,9 +139,9 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
-        return Yii::app()->createUrl("termine/anzeigen", array_merge(array("id" => $this->id), $add_params));
+        return Yii::app()->createUrl("termine/anzeigen", array_merge(["id" => $this->id], $add_params));
     }
 
 
@@ -196,13 +196,13 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
     public function termine_stadtrat_zeitraum($ba_nr, $zeit_von, $zeit_bis, $aufsteigend = true, $limit = 0)
     {
         $ba_sql = ($ba_nr > 0 ? " = " . IntVal($ba_nr) : " IS NULL ");
-        $params = array(
+        $params = [
             'condition' => 'termin.ba_nr ' . $ba_sql . ' AND termin.typ = ' . IntVal(Termin::$TYP_AUTO) .
                 ' AND termin >= "' . addslashes($zeit_von) . '" AND termin <= "' . addslashes($zeit_bis) . '"',
             'order'     => 'termin ' . ($aufsteigend ? "ASC" : "DESC"),
-            'with'      => array("gremium"),
+            'with'      => ["gremium"],
             'alias'     => 'termin'
-        );
+        ];
         if ($limit > 0) $params['limit'] = $limit;
         $this->getDbCriteria()->mergeWith($params);
         return $this;
@@ -227,14 +227,14 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
     {
         $ba_sql = "ba_nr IS NULL";
 
-        $params = array(
+        $params = [
             'condition' => $ba_sql . ' AND datum_letzte_aenderung >= "' . addslashes($zeit_von) . '" AND datum_letzte_aenderung <= "' . addslashes($zeit_bis) . '"',
             'order'     => 'datum DESC',
-            'with'      => array(
-                'antraegeDokumente' => array(
+            'with'      => [
+                'antraegeDokumente' => [
                     'condition' => 'name like "%protokoll%" AND datum >= "' . addslashes($zeit_von) . '" AND datum <= "' . addslashes($zeit_bis) . '"',
-                ),
-            ));
+                ],
+            ]];
         if ($limit > 0) $params['limit'] = $limit;
         $this->getDbCriteria()->mergeWith($params);
         return $this;
@@ -251,14 +251,14 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
     {
         $ba_sql = "ba_nr = " . IntVal($ba_nr);
 
-        $params = array(
+        $params = [
             'condition' => $ba_sql . ' AND datum_letzte_aenderung >= "' . addslashes($zeit_von) . '" AND datum_letzte_aenderung <= "' . addslashes($zeit_bis) . '"',
             'order'     => 'datum DESC',
-            'with'      => array(
-                'antraegeDokumente' => array(
+            'with'      => [
+                'antraegeDokumente' => [
                     'condition' => 'datum >= "' . addslashes($zeit_von) . '" AND datum <= "' . addslashes($zeit_bis) . '"',
-                ),
-            ));
+                ],
+            ]];
         if ($limit > 0) $params['limit'] = $limit;
         $this->getDbCriteria()->mergeWith($params);
         return $this;
@@ -305,7 +305,7 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
         } else {
             $datum_long = strftime("%e. %B %Y, %H:%M Uhr", $ts);
         }
-        return array(
+        return [
             "id"         => $this->id,
             "typ"        => $this->typ,
             "link"       => $this->getLink(),
@@ -314,11 +314,11 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
             "datum_iso"  => $this->termin,
             "datum_ts"   => $ts,
             "abgesagt"   => $this->istAbgesagt(),
-            "gremien"    => array(),
+            "gremien"    => [],
             "ort"        => $this->sitzungsort,
-            "tos"        => array(),
+            "tos"        => [],
             "dokumente"  => $this->antraegeDokumente,
-        );
+        ];
     }
 
 
@@ -328,13 +328,13 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
      */
     public static function groupAppointments($appointments)
     {
-        $data = array();
+        $data = [];
         foreach ($appointments as $appointment) {
             $key = $appointment->termin . $appointment->sitzungsort;
             if (!isset($data[$key])) $data[$key] = $appointment->toArr();
-            $url = Yii::app()->createUrl("termine/anzeigen", array("termin_id" => $appointment->id));
+            $url = Yii::app()->createUrl("termine/anzeigen", ["termin_id" => $appointment->id]);
             if ($appointment->gremium) {
-                if (!isset($data[$key]["gremien"][$appointment->gremium->name])) $data[$key]["gremien"][$appointment->gremium->name] = array();
+                if (!isset($data[$key]["gremien"][$appointment->gremium->name])) $data[$key]["gremien"][$appointment->gremium->name] = [];
                 $data[$key]["gremien"][$appointment->gremium->name][] = $url;
             }
         }
@@ -347,7 +347,7 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
      */
     public function errateAktuellsteTagesordnung()
     {
-        $tos = array();
+        $tos = [];
         foreach ($this->antraegeDokumente as $dok) {
             $name = $dok->getName(true);
             if (stripos($name, "tagesordnung") !== false || stripos($name, "einladung") !== false) $tos[] = $dok;
@@ -372,7 +372,7 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
     {
 
         /** @var Termin[] $alle_termine */
-        $alle_termine = array();
+        $alle_termine = [];
 
         /**
          * @param Termin[] $alle_termine
@@ -419,17 +419,17 @@ class Termin extends CActiveRecord implements IRISItemHasDocuments
      */
     public function getVEventParams()
     {
-        $description = "Infoseite: " . SITE_BASE_URL . Yii::app()->createUrl("termine/anzeigen", array("termin_id" => $this->id));
+        $description = "Infoseite: " . SITE_BASE_URL . Yii::app()->createUrl("termine/anzeigen", ["termin_id" => $this->id]);
         foreach ($this->antraegeDokumente as $dok) {
             $description .= "\n" . $dok->getName() . ": " . $dok->getLink();
         }
         $ende = date("Y-m-d H:i:s", RISTools::date_iso2timestamp($this->termin) + 3600);
-        return array(
+        return [
             'SUMMARY'     => $this->getName(true),
             'DTSTART'     => new \DateTime($this->termin, new DateTimeZone("Europe/Berlin")),
             'DTEND'       => new \DateTime($ende, new DateTimeZone("Europe/Berlin")),
             'LOCATION'    => $this->sitzungsort,
             'DESCRIPTION' => $description,
-        );
+        ];
     }
 }

--- a/protected/models/TerminHistory.php
+++ b/protected/models/TerminHistory.php
@@ -47,14 +47,14 @@ class TerminHistory extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, typ, datum_letzte_aenderung', 'required'),
-            array('id, typ, termin_reihe, gremium_id, ba_nr, termin_prev_id, termin_next_id', 'numerical', 'integerOnly' => true),
-            array('referat, referent, vorsitz', 'length', 'max' => 200),
-            array('wahlperiode', 'length', 'max' => 20),
-            array('status', 'length', 'max' => 100),
-            array('termin', 'safe'),
-        );
+        return [
+            ['id, typ, datum_letzte_aenderung', 'required'],
+            ['id, typ, termin_reihe, gremium_id, ba_nr, termin_prev_id, termin_next_id', 'numerical', 'integerOnly' => true],
+            ['referat, referent, vorsitz', 'length', 'max' => 200],
+            ['wahlperiode', 'length', 'max' => 20],
+            ['status', 'length', 'max' => 100],
+            ['termin', 'safe'],
+        ];
     }
 
     /**
@@ -64,7 +64,7 @@ class TerminHistory extends CActiveRecord
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array();
+        return [];
     }
 
     /**
@@ -72,7 +72,7 @@ class TerminHistory extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                     => 'ID',
             'typ'                    => 'Typ',
             'datum_letzte_aenderung' => 'Datum Letzte Aenderung',
@@ -88,6 +88,6 @@ class TerminHistory extends CActiveRecord
             'vorsitz'                => 'Vorsitz',
             'wahlperiode'            => 'Wahlperiode',
             'status'                 => 'Status',
-        );
+        ];
     }
 }

--- a/protected/models/Text.php
+++ b/protected/models/Text.php
@@ -46,12 +46,12 @@ class Text extends CActiveRecord
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('typ, titel', 'required'),
-            array('id, typ, pos, edit_benutzerIn_id', 'numerical', 'integerOnly' => true),
-            array('titel', 'length', 'max' => 180),
-            array('typ, pos, text, titel', 'safe'),
-        );
+        return [
+            ['typ, titel', 'required'],
+            ['id, typ, pos, edit_benutzerIn_id', 'numerical', 'integerOnly' => true],
+            ['titel', 'length', 'max' => 180],
+            ['typ, pos, text, titel', 'safe'],
+        ];
     }
 
     /**
@@ -59,9 +59,9 @@ class Text extends CActiveRecord
      */
     public function relations()
     {
-        return array(
-            'edit_benutzerIn' => array(self::BELONGS_TO, 'Person', 'edit_benutzerIn_id'),
-        );
+        return [
+            'edit_benutzerIn' => [self::BELONGS_TO, 'Person', 'edit_benutzerIn_id'],
+        ];
     }
 
     /**
@@ -69,7 +69,7 @@ class Text extends CActiveRecord
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'                 => 'ID',
             'typ'                => 'Typ',
             'pos'                => 'Position',
@@ -78,7 +78,7 @@ class Text extends CActiveRecord
             'edit_datum'         => 'Zuletzt bearbeitet: Datum',
             'edit_benutzerIn'    => 'Zuletzt bearbeitet: BenutzerIn',
             'edit_benutzerIn_id' => 'Zuletzt bearbeitet: BenutzerIn-ID',
-        );
+        ];
     }
 
 }

--- a/protected/models/Vorgang.php
+++ b/protected/models/Vorgang.php
@@ -39,11 +39,11 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you should only define rules for those attributes that
         // will receive user inputs.
-        return array(
-            array('id, typ', 'required'),
-            array('id, typ', 'numerical', 'integerOnly' => true),
-            array('betreff', 'length', 'max' => 200),
-        );
+        return [
+            ['id, typ', 'required'],
+            ['id, typ', 'numerical', 'integerOnly' => true],
+            ['betreff', 'length', 'max' => 200],
+        ];
     }
 
     /**
@@ -53,11 +53,11 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
     {
         // NOTE: you may need to adjust the relation name and the related
         // class name for the relations automatically generated below.
-        return array(
-            'antraege'   => array(self::HAS_MANY, 'Antrag', 'vorgang_id'),
-            'ergebnisse' => array(self::HAS_MANY, 'Tagesordnungspunkt', 'vorgang_id'),
-            'dokumente'  => array(self::HAS_MANY, 'Dokument', 'vorgang_id'),
-        );
+        return [
+            'antraege'   => [self::HAS_MANY, 'Antrag', 'vorgang_id'],
+            'ergebnisse' => [self::HAS_MANY, 'Tagesordnungspunkt', 'vorgang_id'],
+            'dokumente'  => [self::HAS_MANY, 'Dokument', 'vorgang_id'],
+        ];
     }
 
     /**
@@ -65,11 +65,11 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
      */
     public function attributeLabels()
     {
-        return array(
+        return [
             'id'      => 'ID',
             'typ'     => 'Typ',
             'betreff' => 'Betreff',
-        );
+        ];
     }
 
     /**
@@ -78,7 +78,7 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
     public function getRISItemsByDate()
     {
         /** @var IRISItem[] $items */
-        $items = array();
+        $items = [];
         foreach ($this->antraege as $ant) $items[] = $ant;
         foreach ($this->dokumente as $dok) $items[] = $dok;
         foreach ($this->ergebnisse as $erg) $items[] = $erg;
@@ -137,7 +137,7 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
         try {
             Yii::app()->db
                 ->createCommand("INSERT INTO `benutzerInnen_vorgaenge_abos` (`benutzerInnen_id`, `vorgaenge_id`) VALUES (:BenutzerInId, :VorgangId)")
-                ->bindValues(array(':VorgangId' => $this->id, ':BenutzerInId' => $benutzerIn->id))
+                ->bindValues([':VorgangId' => $this->id, ':BenutzerInId' => $benutzerIn->id])
                 ->execute();
         } catch (CDbException $e) {
             if ($e->errorInfo[1] != 1062) throw $e; // Duplicate Entry, ist ok
@@ -151,7 +151,7 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
     {
         Yii::app()->db
             ->createCommand("DELETE FROM `benutzerInnen_vorgaenge_abos` WHERE `benutzerInnen_id` = :BenutzerInId AND `vorgaenge_id` = :VorgangId")
-            ->bindValues(array(':VorgangId' => $this->id, ':BenutzerInId' => $benutzerIn->id))
+            ->bindValues([':VorgangId' => $this->id, ':BenutzerInId' => $benutzerIn->id])
             ->execute();
     }
 
@@ -189,12 +189,12 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
 
             Yii::app()->db
                 ->createCommand("UPDATE IGNORE `benutzerInnen_vorgaenge_abos` SET vorgaenge_id = :VorgangIdNeu WHERE vorgaenge_id = :VorgangIdAlt")
-                ->bindValues(array(':VorgangIdNeu' => $vorgang_zu_id, ':VorgangIdAlt' => $vorgang_von_id))
+                ->bindValues([':VorgangIdNeu' => $vorgang_zu_id, ':VorgangIdAlt' => $vorgang_von_id])
                 ->execute();
 
             Yii::app()->db
                 ->createCommand("DELETE FROM `benutzerInnen_vorgaenge_abos` WHERE vorgaenge_id = :VorgangIdAlt")
-                ->bindValues(array(':VorgangIdAlt' => $vorgang_von_id))
+                ->bindValues([':VorgangIdAlt' => $vorgang_von_id])
                 ->execute();
 
             $str .= "Gelöscht.\n";
@@ -208,7 +208,7 @@ class Vorgang extends CActiveRecord implements IRISItemHasDocuments
      * @param array $add_params
      * @return string
      */
-    public function getLink($add_params = array())
+    public function getLink($add_params = [])
     {
         // TODO: Implement getLink() method.
     }

--- a/protected/views/antraege/anzeige.php
+++ b/protected/views/antraege/anzeige.php
@@ -8,10 +8,10 @@
 $this->pageTitle         = $antrag->getName(true);
 $this->load_selectize_js = true;
 
-$personen = array(
-    AntragPerson::$TYP_GESTELLT_VON => array(),
-    AntragPerson::$TYP_INITIATORIN  => array(),
-);
+$personen = [
+    AntragPerson::$TYP_GESTELLT_VON => [],
+    AntragPerson::$TYP_INITIATORIN  => [],
+];
 foreach ($antrag->antraegePersonen as $ap) $personen[$ap->typ][] = $ap->person;
 
 $historie = $antrag->getHistoryDiffs();
@@ -104,7 +104,7 @@ function verbundene_anzeigen($antraege, $ueberschrift, $this2) {
                         <?
                         } else {
                             ?>
-                            <form method="POST" action="<?= CHtml::encode($antrag->getLink(array("tag_mode" => 1))) ?>"
+                            <form method="POST" action="<?= CHtml::encode($antrag->getLink(["tag_mode" => 1])) ?>"
                                   class="login_modal_form">
                                 <?
                                 $this->renderPartial("../index/login_modal");
@@ -311,7 +311,7 @@ function verbundene_anzeigen($antraege, $ueberschrift, $this2) {
         ?>
         <div class="well themenverwandt_liste" id="themenverwandt">
 
-            <form method="POST" action="<?= Yii::app()->createUrl("antraege/anzeigen", array("id" => $antrag->id)) ?>"
+            <form method="POST" action="<?= Yii::app()->createUrl("antraege/anzeigen", ["id" => $antrag->id]) ?>"
                   class="abo_button row_head"
                   style="min-height: 80px; text-align: center;">
                 <?
@@ -347,7 +347,7 @@ function verbundene_anzeigen($antraege, $ueberschrift, $this2) {
                     ?>
                 </ul>
 
-                <a href="<?= CHtml::encode(Yii::app()->createUrl("antraege/themenverwandte", array("id" => $antrag->id))) ?>"
+                <a href="<?= CHtml::encode(Yii::app()->createUrl("antraege/themenverwandte", ["id" => $antrag->id])) ?>"
                    class="weitere">
                     Weitere Themenverwandte <span class="glyphicon glyphicon-chevron-right"></span>
                 </a>

--- a/protected/views/benachrichtigungen/index.php
+++ b/protected/views/benachrichtigungen/index.php
@@ -184,7 +184,7 @@ $benachrichtigungstag = $ich->getEinstellungen()->benachrichtigungstag;
                     <a href="<?= CHtml::encode($this->createUrl("benachrichtigungen/alleSuchergebnisse")) ?>" class="ben_alle_suche"><span
                             class="glyphicon glyphicon-chevron-right"></span>
                         Alle Suchergebnisse</a>
-                    <a href="<?= CHtml::encode($this->createUrl("benachrichtigungen/alleFeed", array("code" => $ich->getFeedCode()))) ?>" class="ben_alle_feed"><span
+                    <a href="<?= CHtml::encode($this->createUrl("benachrichtigungen/alleFeed", ["code" => $ich->getFeedCode()])) ?>" class="ben_alle_feed"><span
                             class="fontello-rss"></span>
                         Alle Suchergebnisse als Feed</a>
                 </div>

--- a/protected/views/benachrichtigungen/suchergebnisse_email_txt.php
+++ b/protected/views/benachrichtigungen/suchergebnisse_email_txt.php
@@ -91,7 +91,7 @@ foreach ($data["termine"] as $dat) {
 }
 }
 ?>
-Falls du diese Benachrichtigung nicht mehr erhalten willst, kannst du sie unter <?php echo trim(Yii::app()->createUrl("benachrichtigungen/index", array("code" => $benutzerIn->getBenachrichtigungAbmeldenCode())), "."); ?> abbestellen.
+Falls du diese Benachrichtigung nicht mehr erhalten willst, kannst du sie unter <?php echo trim(Yii::app()->createUrl("benachrichtigungen/index", ["code" => $benutzerIn->getBenachrichtigungAbmeldenCode()]), "."); ?> abbestellen.
 
 Liebe Grüße
   Das München Transparent-Team

--- a/protected/views/index/ba_startseite.php
+++ b/protected/views/index/ba_startseite.php
@@ -135,7 +135,7 @@ $this->pageTitle = "Bezirksausschuss " . $ba->ba_nr . ", " . $ba->name;
             ));
             ?>
             <div style="text-align: right; font-size: 1.5em;">
-                <a href="<?=CHtml::encode($this->createUrl("termine/baTermineAlle", array("ba_nr" => $ba->ba_nr)))?>">
+                <a href="<?=CHtml::encode($this->createUrl("termine/baTermineAlle", ["ba_nr" => $ba->ba_nr]))?>">
                     Alle Termine <span class="glyphicon glyphicon-chevron-right"></span>
                 </a>
             </div>

--- a/protected/views/index/index_antraege_liste.php
+++ b/protected/views/index/index_antraege_liste.php
@@ -35,7 +35,7 @@ if (isset($title) && $title !== null) {
     $erkl_str = "Stadtratsdokumente: etwa ${radius}m um \"" . CHtml::encode($naechster_ort->ort) . "\"";
 }
 
-if (!isset($rathausumschauen)) $rathausumschauen = array();
+if (!isset($rathausumschauen)) $rathausumschauen = [];
 if (!isset($zeige_ba_orte)) $zeige_ba_orte = 0;
 
 $datum_nav = ((isset($neuere_url_std) && $neuere_url_std !== null) || (isset($aeltere_url_std) && $aeltere_url_std !== null));

--- a/protected/views/index/quicksearch_prefetch.php
+++ b/protected/views/index/quicksearch_prefetch.php
@@ -9,22 +9,22 @@ $this->layout=false;
 header('Content-type: application/json; charset=UTF-8');
 
 
-$output_data = array();
+$output_data = [];
 foreach ($stadtraetInnen as $str) {
 	$fraktion = "";
-	$gremien = array();
+	$gremien = [];
 	foreach ($str->stadtraetInnenFraktionen as $fr) {
 		$fraktion = $fr->fraktion->name;
 		$gremium = ($fr->fraktion->ba_nr > 0 ? "BA " . $fr->fraktion->ba_nr : "Stadtrat");
 		if (!in_array($gremium, $gremien)) $gremien[] = $gremium;
 	} // @TODO
 
-	$output_data[] = array(
+	$output_data[] = [
 		"value" => $str->getName(),
 		"fraktionen" => $fraktion,
 		"gremien" => implode(", ", $gremien),
 		"url" => $str->getLink()
-	);
+	];
 }
 
 echo json_encode($output_data);

--- a/protected/views/index/startseite.php
+++ b/protected/views/index/startseite.php
@@ -16,7 +16,7 @@
  */
 
 $this->pageTitle = Yii::app()->name;
-$ba_links = array();
+$ba_links = [];
 /** @var Bezirksausschuss[] $bas */
 $bas = Bezirksausschuss::model()->findAll();
 foreach ($bas as $ba) $ba_links["ba_" . $ba->ba_nr] = $ba->getLink();

--- a/protected/views/infos/glossar_bearbeiten.php
+++ b/protected/views/infos/glossar_bearbeiten.php
@@ -9,7 +9,7 @@ $this->pageTitle = "Glossar bearbeiten";
 	<h2>Eintrag bearbeiten</h2>
 	<a href="<?= CHtml::encode(Yii::app()->createUrl("infos/glossar")) ?>"><span class="glyphicon glyphicon-arrow-left"></span> Zurück</a><br>
 
-	<form method="POST" action="<?= CHtml::encode(Yii::app()->createUrl("infos/glossarBearbeiten", array("id" => $eintrag->id))) ?>" role="form" class="well"
+	<form method="POST" action="<?= CHtml::encode(Yii::app()->createUrl("infos/glossarBearbeiten", ["id" => $eintrag->id])) ?>" role="form" class="well"
 		  style="max-width: 850px; margin-top: 50px; margin-left: auto; margin-right: auto;">
 
 		<div class="form-group">
@@ -23,7 +23,7 @@ $this->pageTitle = "Glossar bearbeiten";
 			<textarea id="glossary_new_text" name="text" cols="80" rows="10"><?=CHtml::encode($eintrag->text)?></textarea>
 		</div>
 
-		<a href="<?=CHtml::encode($this->createUrl("infos/glossarBearbeiten", array("id" => $eintrag->id, AntiXSS::createToken("del") => "1")))?>" id="eintrag_del_caller" style="color: red; float: right;">
+		<a href="<?=CHtml::encode($this->createUrl("infos/glossarBearbeiten", ["id" => $eintrag->id, AntiXSS::createToken("del") => "1"]))?>" id="eintrag_del_caller" style="color: red; float: right;">
 			<span class="glyphicon glyphicon-minus"></span> Eintrag löschen
 		</a>
 

--- a/protected/views/layouts/main.php
+++ b/protected/views/layouts/main.php
@@ -120,7 +120,7 @@ echo ris_intern_html_extra_headers();
                     <input type="text" name="suchbegriff" value="<?= CHtml::encode($this->suche_pre) ?>" placeholder="Volltextsuche" class="form-control"
                            id="quicksearch_form_input" required
                            data-prefetch-url="<?= CHtml::encode($this->createUrl("index/quickSearchPrefetch")) ?>"
-                           data-search-url="<?= CHtml::encode($this->createUrl("index/suche", array("suchbegriff" => "SUCHBEGRIFF"))) ?>">
+                           data-search-url="<?= CHtml::encode($this->createUrl("index/suche", ["suchbegriff" => "SUCHBEGRIFF"])) ?>">
                     <button type="submit" class="btn btn-success" id="quicksearch_form_submit"><span class="glyphicon glyphicon-search"></span><span class="sr-only">Suchen</span>
                     </button>
                 </form>

--- a/protected/views/termine/abo_info.php
+++ b/protected/views/termine/abo_info.php
@@ -10,7 +10,7 @@
         <ul class="breadcrumb" style="margin-bottom: 5px;">
             <li><a href="<?= CHtml::encode(Yii::app()->createUrl("index/startseite")) ?>">Startseite</a><br></li>
             <li><a href="<?= CHtml::encode(Yii::app()->createUrl("termine/index")) ?>">Termine</a><br></li>
-            <li><a href="<?= CHtml::encode(Yii::app()->createUrl("termine/anzeigen", array("termin_id" => $termin->id))) ?>">Termin</a><br></li>
+            <li><a href="<?= CHtml::encode(Yii::app()->createUrl("termine/anzeigen", ["termin_id" => $termin->id])) ?>">Termin</a><br></li>
             <li class="active">Export</li>
         </ul>
 

--- a/protected/views/termine/anzeige.php
+++ b/protected/views/termine/anzeige.php
@@ -8,7 +8,7 @@
 
 $this->pageTitle = $termin->getName(true);
 $assets_base     = $this->getAssetsBase();
-$geodata         = array();
+$geodata         = [];
 
 function zeile_anzeigen($feld, $name, $callback)
 {
@@ -107,7 +107,7 @@ function zeile_anzeigen($feld, $name, $callback)
 				<div id="map"></div>
 			</div>
 			<!--
-			<a href="<?= Yii::app()->createUrl("termine/topGeoExport", array("termin_id" => $termin->id)) ?>" style="float: right;" rel="nofollow">Großversion der Karte exportieren
+			<a href="<?= Yii::app()->createUrl("termine/topGeoExport", ["termin_id" => $termin->id]) ?>" style="float: right;" rel="nofollow">Großversion der Karte exportieren
 				<span class="fontello-right-open"></span></a>-->
 		</section>
 		<br>

--- a/protected/views/termine/top_geo_export.php
+++ b/protected/views/termine/top_geo_export.php
@@ -8,11 +8,11 @@ $assets_base = $this->getAssetsBase();
 
 foreach ($termin->tagesordnungspunkte as $ergebnis) {
 	$geo = $ergebnis->get_geo();
-	foreach ($geo as $g) $geodata[] = array(
+	foreach ($geo as $g) $geodata[] = [
 		FloatVal($g->lat),
 		FloatVal($g->lon),
 		str_replace(".", ".<br>", trim($ergebnis->top_nr, "."))
-	);
+	];
 }
 ?>
 <html>


### PR DESCRIPTION
Ich habe mit Hilfe von https://github.com/thomasbachem/php-short-array-syntax-converter alle `array(...)` durch `[....]` ersetzt. Damit wird der Code an vielen Stellen kompakter und besser lesbar. Der einzige Nachteil ist, dass dafür mindestens PHP 5.4 benötigt wird.