### PR TITLE
Fixed the reported OParl Version

### DIFF
--- a/protected/controllers/Oparl10Controller.php
+++ b/protected/controllers/Oparl10Controller.php
@@ -4,7 +4,7 @@
  * Enhält alle actions für OParl 1.0 sowie einige Hilfsmethoden
  */
 class OParl10Controller extends CController {
-    const VERSION = 'https://oparl.org/specs/1.0/';
+    const VERSION = 'https://schema.oparl.org/1.0/';
 
     /**
      * Erzeugt die URL zu einem einzelnen OParl-Objekt


### PR DESCRIPTION
The version string of System.oparlVersion must be `https://schema.oparl.org/1.0/`
according to https://dev.oparl.org/spezifikation/#entity-system.