### PR TITLE
Ignore Vorlagen without kurzinfo

### DIFF
--- a/protected/RISParser/StadtratsvorlageParser.php
+++ b/protected/RISParser/StadtratsvorlageParser.php
@@ -37,6 +37,8 @@ class StadtratsvorlageParser extends RISParser
             }
             $txt             = explode("</div>", $txt[1]);
             $daten->kurzinfo = trim(str_replace(["<br />", "<p>", "</p>"], ["", "", ""], $txt[0]));
+        } else {
+            return;
         }
 
         $dat_details = explode("<!-- bereichsbild, bereichsheadline, allgemeiner text -->", $html_details);


### PR DESCRIPTION
@CatoTH Das sollte die "RIS Exception Vorlagen" E-Mails wegen https://www.ris-muenchen.de/RII/RII/ris_vorlagen_detail.jsp?risid=5905800 abstellen. Soweit ich das sehen kann lässt sich 5905800 sowieso nicht sinnvoll darstellen.